### PR TITLE
Preserve operator workspace slots during targeted relink

### DIFF
--- a/MUDALIST.md
+++ b/MUDALIST.md
@@ -1,0 +1,7 @@
+# MUDALIST
+
+## 2026-07-07 | Operator Workspace Slot Override
+
+- Debt: Pooler now supports operator-created workspace slots when OpenAI OAuth omits workspace identity for multiple business seats under one account.
+- Interest: Medium. Future upstream auth changes may make the override unnecessary, and operators must preserve the local patch until an official release includes it.
+- Mitigation: Regression test covers targeted relink into an operator slot with missing OAuth workspace claims. ADR: `docs/adr/001_operator_workspace_slots.md`.

--- a/docs/adr/001_operator_workspace_slots.md
+++ b/docs/adr/001_operator_workspace_slots.md
@@ -1,0 +1,25 @@
+# 2026-07-07 | DECISION | Preserve Operator Workspace Slots During Targeted Relink
+
+## Decision
+
+Codex Pooler supports operator-created workspace slots for ChatGPT business seats that share the same `chatgpt_account_id` when OpenAI OAuth omits a workspace identifier. During a targeted relink, Pooler may accept a missing incoming `workspace_id` only when the selected upstream identity already has a concrete `workspace_id` and its metadata marks it as an operator override:
+
+```json
+{"workspace_slot_source": "operator_override"}
+```
+
+When that condition is met, Pooler preserves the stored `workspace_id`, `workspace_label`, and `seat_type` while replacing the account tokens.
+
+## Alternatives Considered
+
+- Treat all missing workspace claims as legacy account links. This preserves strict OAuth identity matching, but collapses multiple business seats under the same business account.
+- Manually duplicate upstream rows in the database without code support. This creates brittle state and risks later relinks erasing the synthetic slot.
+- Require OpenAI to return a stable workspace claim. This is preferable long-term, but not available for the observed OAuth responses.
+
+## Rationale
+
+The bug is an identity-slot collision: two valid business seats can share a `chatgpt_account_id`, while OpenAI may omit the workspace claim Pooler needs to distinguish them. A targeted relink is already an operator-directed action against a selected upstream. Preserving a pre-created operator slot lets Pooler route each seat independently without weakening normal unassigned link behavior.
+
+## Technical Debt Incurred
+
+This is an operator-managed identity override. It should be replaced if OpenAI exposes a stable workspace or seat identifier in OAuth token claims or an account metadata endpoint.

--- a/lib/codex_pooler/upstreams/token_linking.ex
+++ b/lib/codex_pooler/upstreams/token_linking.ex
@@ -116,6 +116,7 @@ defmodule CodexPooler.Upstreams.TokenLinking do
             |> then(&Map.merge(identity.metadata || %{}, &1))
           end)
           |> Map.put(:account_label, identity.account_label)
+          |> preserve_operator_workspace_slot(identity, attrs)
 
         with {:ok, active_identity} <- activate_identity_with_plan(identity, attrs) do
           {:ok, :existing, active_identity}
@@ -465,6 +466,10 @@ defmodule CodexPooler.Upstreams.TokenLinking do
       is_binary(target_workspace_id) and incoming_workspace_id == target_workspace_id ->
         :ok
 
+      is_binary(target_workspace_id) and is_nil(incoming_workspace_id) and
+          operator_workspace_slot?(target_identity) ->
+        :ok
+
       is_binary(target_workspace_id) ->
         {:error, identity_mismatch_error()}
 
@@ -500,6 +505,20 @@ defmodule CodexPooler.Upstreams.TokenLinking do
   defp maybe_preserve_relink_assignment_label(assignment_attrs, _assignment, _attrs),
     do: assignment_attrs
 
+  defp preserve_operator_workspace_slot(identity_attrs, identity, %{target_identity_id: target_id})
+       when is_binary(target_id) do
+    if operator_workspace_slot?(identity) and is_nil(present_string(Map.get(identity_attrs, :workspace_id))) do
+      identity_attrs
+      |> Map.put(:workspace_id, identity.workspace_id)
+      |> Map.put(:workspace_label, identity.workspace_label)
+      |> Map.put(:seat_type, identity.seat_type)
+    else
+      identity_attrs
+    end
+  end
+
+  defp preserve_operator_workspace_slot(identity_attrs, _identity, _attrs), do: identity_attrs
+
   defp exact_workspace_identity?(%UpstreamIdentity{id: target_id}, account_id, workspace_id) do
     case IdentityLifecycle.get_upstream_identity_by_chatgpt_account_and_workspace(
            account_id,
@@ -525,6 +544,11 @@ defmodule CodexPooler.Upstreams.TokenLinking do
       %UpstreamIdentity{} = identity ->
         not is_nil(present_string(identity.workspace_id))
     end)
+  end
+
+  defp operator_workspace_slot?(%UpstreamIdentity{metadata: metadata, workspace_id: workspace_id}) do
+    present_string(workspace_id) != nil and
+      is_map(metadata) and metadata["workspace_slot_source"] == "operator_override"
   end
 
   defp target_identity_id(opts) do

--- a/scripts/self-host/build-operator-workspace-slot-image.sh
+++ b/scripts/self-host/build-operator-workspace-slot-image.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+IMAGE_NAME="${CODEX_POOLER_OPERATOR_IMAGE_NAME:-codex-pooler}"
+IMAGE_TAG="${CODEX_POOLER_OPERATOR_IMAGE_TAG:-operator-workspace-slot}"
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+cd "$repo_root"
+
+docker build -t "${IMAGE_NAME}:${IMAGE_TAG}" .
+
+cat <<MSG
+Built ${IMAGE_NAME}:${IMAGE_TAG}.
+
+To run this image with Docker Compose, set these in .env:
+CODEX_POOLER_IMAGE=${IMAGE_NAME}
+CODEX_POOLER_IMAGE_TAG=${IMAGE_TAG}
+
+Then recreate only the app container:
+docker compose up -d --no-deps app
+MSG

--- a/test/codex_pooler/upstreams/oauth_relink_test.exs
+++ b/test/codex_pooler/upstreams/oauth_relink_test.exs
@@ -331,6 +331,58 @@ defmodule CodexPooler.Upstreams.OAuthRelinkTest do
     assert Repo.aggregate(EncryptedSecret, :count) == 1
   end
 
+  test "browser relink preserves an operator workspace slot when OAuth omits workspace claims" do
+    scope = fixture_owner_scope()
+    pool = pool_fixture()
+    account_id = "acct_relink_operator_slot"
+
+    legacy_identity = active_upstream_identity_fixture(relink_identity_attrs(account_id, nil))
+
+    operator_slot =
+      active_upstream_identity_fixture(
+        relink_identity_attrs(account_id, "operator:business-seat-2")
+        |> Map.merge(%{
+          account_label: "Second business seat",
+          workspace_label: "Business seat 2",
+          metadata: %{"workspace_slot_source" => "operator_override"}
+        })
+      )
+
+    assert {:ok, slot_assignment} =
+             PoolAssignments.create_pool_assignment(pool, operator_slot)
+
+    start_provider!(%{
+      "/oauth/token" =>
+        {200,
+         FakeOpenAIAuthProvider.token_response(
+           access_token: "operator-slot-access",
+           refresh_token: "operator-slot-refresh",
+           id_token: relink_id_token(account_id, nil)
+         )}
+    })
+
+    assert {:ok, %{flow: flow, authorization_url: authorization_url}} =
+             Upstreams.start_browser_oauth(scope, pool, upstream_identity: operator_slot)
+
+    assert {:ok, %{status: :completed, identity: relinked, assignment: relinked_assignment}} =
+             Upstreams.complete_browser_oauth(
+               scope,
+               flow.id,
+               callback_url(authorization_state(authorization_url), "operator-slot-code")
+             )
+
+    assert relinked.id == operator_slot.id
+    assert relinked.account_label == "Second business seat"
+    assert relinked.workspace_id == "operator:business-seat-2"
+    assert relinked.workspace_label == "Business seat 2"
+    assert relinked_assignment.id == slot_assignment.id
+    assert Repo.get!(UpstreamIdentity, legacy_identity.id).workspace_id == nil
+    assert Repo.aggregate(UpstreamIdentity, :count) == 2
+
+    assert {:ok, "operator-slot-access"} =
+             Secrets.decrypt_active_secret(operator_slot, "access_token")
+  end
+
   defp fixture_owner_scope do
     %{user: user} = bootstrap_owner_fixture(%{"email" => unique_user_email()})
     Scope.for_user(user, ["instance_owner"])


### PR DESCRIPTION
## Summary
- allow targeted OAuth relinks to preserve an operator-created workspace slot when OpenAI omits workspace claims
- add regression coverage for same-account business-seat collisions
- document the operator-slot decision and provide a self-host image rebuild helper

## Verification
- docker build -t codex-pooler:operator-workspace-slot .
- docker run --rm --network host -v <repo>:/app -w /app ... mix test test/codex_pooler/upstreams/oauth_relink_test.exs

## Notes
This addresses business seats that share a ChatGPT account id but need separate Pooler upstream slots. Normal unassigned link behavior remains unchanged; the relaxed missing-workspace check only applies to targeted relinks into identities marked with workspace_slot_source=operator_override.