### PR TITLE
fix(upstreams): converge confirmed saved reset quota

### DIFF
--- a/lib/codex_pooler/upstreams/quota/windows.ex
+++ b/lib/codex_pooler/upstreams/quota/windows.ex
@@ -56,6 +56,7 @@ defmodule CodexPooler.Upstreams.Quota.Windows do
     delete_missing? = Keyword.fetch!(opts, :delete_missing?)
     covered_descriptors = Keyword.get(opts, :covered_descriptors, MapSet.new())
     broadcast? = Keyword.get(opts, :broadcast?, true)
+    evidence_opts = Keyword.take(opts, [:weekly_restart_corroboration])
 
     windows =
       Enum.map(windows, fn attrs ->
@@ -76,7 +77,7 @@ defmodule CodexPooler.Upstreams.Quota.Windows do
         Multi.run(multi, {:quota_window, Evidence.identity_key(attrs)}, fn _repo, _changes ->
           # Reason: Multi callback normalizes quota evidence errors at the boundary.
           # credo:disable-for-next-line Credo.Check.Refactor.Nesting
-          case EvidenceStore.record_evidence(identity, attrs, now()) do
+          case EvidenceStore.record_evidence(identity, attrs, now(), evidence_opts) do
             {:ok, window} -> {:ok, window}
             {:error, %Ecto.Changeset{} = changeset} -> {:error, changeset}
             {:error, errors} -> {:error, quota_window_error_changeset(identity, attrs, errors)}

--- a/lib/codex_pooler/upstreams/quota/windows/evidence_store.ex
+++ b/lib/codex_pooler/upstreams/quota/windows/evidence_store.ex
@@ -14,6 +14,7 @@ defmodule CodexPooler.Upstreams.Quota.Windows.EvidenceStore do
   @weekly_restart_anchor_margin_seconds 60 * 60
   @usage_reset_reanchor_min_shift_seconds 60 * 60
   @restart_corroboration_reset_tolerance_seconds 5 * 60
+  @saved_reset_corroboration_max_age_seconds 24 * 60 * 60
   @relative_reset_refresh_tolerance_seconds 5
   @account_snapshot_reset_tolerance_seconds 5
   @candidate_metadata_key "__quota_confirmed_candidate_v1"
@@ -49,24 +50,39 @@ defmodule CodexPooler.Upstreams.Quota.Windows.EvidenceStore do
           {:ok, Quota.AccountQuotaWindow.t()}
           | {:error, Ecto.Changeset.t() | Evidence.errors() | map()}
   def record_evidence(identity_or_id, attrs, observed_at) do
-    record_evidence(identity_or_id, attrs, observed_at, now())
+    record_evidence(identity_or_id, attrs, observed_at, now(), [])
   end
 
   @spec record_evidence(identity_ref(), map(), DateTime.t(), DateTime.t()) ::
           {:ok, Quota.AccountQuotaWindow.t()}
           | {:error, Ecto.Changeset.t() | Evidence.errors() | map()}
-  def record_evidence(identity_or_id, attrs, observed_at, timestamp) do
+  def record_evidence(identity_or_id, attrs, observed_at, %DateTime{} = timestamp) do
+    record_evidence(identity_or_id, attrs, observed_at, timestamp, [])
+  end
+
+  @spec record_evidence(identity_ref(), map(), DateTime.t(), keyword()) ::
+          {:ok, Quota.AccountQuotaWindow.t()}
+          | {:error, Ecto.Changeset.t() | Evidence.errors() | map()}
+  def record_evidence(identity_or_id, attrs, observed_at, opts) when is_list(opts) do
+    record_evidence(identity_or_id, attrs, observed_at, now(), opts)
+  end
+
+  @spec record_evidence(identity_ref(), map(), DateTime.t(), DateTime.t(), keyword()) ::
+          {:ok, Quota.AccountQuotaWindow.t()}
+          | {:error, Ecto.Changeset.t() | Evidence.errors() | map()}
+  def record_evidence(identity_or_id, attrs, observed_at, timestamp, opts)
+      when is_struct(timestamp, DateTime) and is_list(opts) do
     if Repo.in_transaction?() do
-      record_evidence_in_transaction(identity_or_id, attrs, observed_at, timestamp)
+      record_evidence_in_transaction(identity_or_id, attrs, observed_at, timestamp, opts)
     else
-      record_evidence_in_new_transaction(identity_or_id, attrs, observed_at, timestamp)
+      record_evidence_in_new_transaction(identity_or_id, attrs, observed_at, timestamp, opts)
     end
   end
 
-  defp record_evidence_in_new_transaction(identity_or_id, attrs, observed_at, timestamp) do
+  defp record_evidence_in_new_transaction(identity_or_id, attrs, observed_at, timestamp, opts) do
     Repo.transaction(fn ->
       identity_or_id
-      |> record_evidence_in_transaction(attrs, observed_at, timestamp)
+      |> record_evidence_in_transaction(attrs, observed_at, timestamp, opts)
       |> unwrap_record_evidence_transaction()
     end)
   end
@@ -74,7 +90,7 @@ defmodule CodexPooler.Upstreams.Quota.Windows.EvidenceStore do
   defp unwrap_record_evidence_transaction({:ok, window}), do: window
   defp unwrap_record_evidence_transaction({:error, reason}), do: Repo.rollback(reason)
 
-  defp record_evidence_in_transaction(identity_or_id, attrs, observed_at, timestamp) do
+  defp record_evidence_in_transaction(identity_or_id, attrs, observed_at, timestamp, opts) do
     with {:ok, evidence} <- Evidence.new(attrs, observed_at),
          identity_id when is_binary(identity_id) <- evidence_identity_id(identity_or_id, attrs) do
       advisory_lock_evidence_identity(identity_id)
@@ -85,7 +101,7 @@ defmodule CodexPooler.Upstreams.Quota.Windows.EvidenceStore do
         |> Map.put(:upstream_identity_id, identity_id)
 
       with {:ok, existing} <- get_existing_evidence(identity_id, evidence) do
-        timestamped_attrs = merge_attrs(existing, attrs, evidence, timestamp)
+        timestamped_attrs = merge_attrs(existing, attrs, evidence, timestamp, opts)
 
         result =
           existing
@@ -288,21 +304,192 @@ defmodule CodexPooler.Upstreams.Quota.Windows.EvidenceStore do
       optional_string(window.raw_metered_feature) == optional_string(evidence.raw_metered_feature)
   end
 
-  defp merge_attrs(%Quota.AccountQuotaWindow{id: nil} = existing, attrs, _evidence, _timestamp),
-    do: put_timestamps(attrs, existing)
+  defp merge_attrs(
+         %Quota.AccountQuotaWindow{id: nil} = existing,
+         attrs,
+         _evidence,
+         _timestamp,
+         _opts
+       ),
+       do: put_timestamps(attrs, existing)
 
   defp merge_attrs(
          %Quota.AccountQuotaWindow{} = existing,
          attrs,
          %Evidence{} = evidence,
-         timestamp
+         timestamp,
+         opts
        ) do
-    if uncorroborated_zero_reenable_attempt?(evidence, existing, timestamp) do
-      rejected_snapshot_attrs(existing, evidence, timestamp)
-    else
-      merge_attrs_by_decision(existing, attrs, evidence, timestamp)
+    cond do
+      saved_reset_weekly_restart_corroborated?(evidence, existing, timestamp, opts) ->
+        accepted_snapshot_attrs(existing, attrs, timestamp)
+
+      uncorroborated_zero_reenable_attempt?(evidence, existing, timestamp) ->
+        rejected_snapshot_attrs(existing, evidence, timestamp)
+
+      true ->
+        merge_attrs_by_decision(existing, attrs, evidence, timestamp)
     end
   end
+
+  # A saved-reset consume response is an independent provider assertion that
+  # the account weekly cycle restarted. Evidence observed before the provider
+  # response is causally older than that confirmation even when its database
+  # write lands later. Runtime evidence observed after confirmation remains an
+  # independent contradiction and keeps the ordinary fail-closed guard active.
+  defp saved_reset_weekly_restart_corroborated?(
+         %Evidence{
+           source: "codex_usage_api",
+           used_percent: %Decimal{} = incoming_percent,
+           reset_at: %DateTime{}
+         } = evidence,
+         %Quota.AccountQuotaWindow{used_percent: %Decimal{}} = existing,
+         timestamp,
+         opts
+       ) do
+    case Keyword.get(opts, :weekly_restart_corroboration) do
+      {:saved_reset_redemption, credential_epoch, %DateTime{} = started_at,
+       %DateTime{} = confirmed_at}
+      when is_integer(credential_epoch) and credential_epoch > 0 ->
+        saved_reset_weekly_snapshot_transition?(
+          evidence,
+          existing,
+          incoming_percent,
+          timestamp
+        ) and
+          saved_reset_confirmation_allows_transition?(
+            evidence,
+            existing,
+            started_at,
+            confirmed_at,
+            timestamp
+          )
+
+      _corroboration ->
+        false
+    end
+  end
+
+  defp saved_reset_weekly_restart_corroborated?(
+         _evidence,
+         _existing,
+         _timestamp,
+         _opts
+       ),
+       do: false
+
+  defp saved_reset_weekly_snapshot_transition?(
+         evidence,
+         existing,
+         incoming_percent,
+         timestamp
+       ) do
+    account_weekly_evidence?(evidence) and
+      same_evidence_identity?(evidence, existing) and
+      zero_percent?(incoming_percent) and
+      exhausted_by_used_percent?(existing) and
+      Evidence.current_freshness_state(evidence, timestamp) == "fresh" and
+      not Evidence.expired?(evidence, timestamp) and
+      saved_reset_forward_weekly_cycle?(evidence, existing)
+  end
+
+  defp saved_reset_confirmation_allows_transition?(
+         evidence,
+         existing,
+         started_at,
+         confirmed_at,
+         timestamp
+       ) do
+    saved_reset_precedes_transition?(
+      existing,
+      evidence,
+      started_at,
+      confirmed_at,
+      timestamp
+    ) and
+      not runtime_evidence_after_saved_reset?(
+        evidence,
+        existing,
+        confirmed_at,
+        timestamp
+      )
+  end
+
+  defp saved_reset_forward_weekly_cycle?(
+         %Evidence{
+           window_minutes: 10_080,
+           reset_at: %DateTime{} = incoming_reset,
+           observed_at: %DateTime{} = incoming_observed_at
+         },
+         %Quota.AccountQuotaWindow{reset_at: %DateTime{} = existing_reset}
+       ) do
+    window_seconds = 10_080 * 60
+    remaining_seconds = DateTime.diff(incoming_reset, incoming_observed_at, :second)
+
+    DateTime.diff(incoming_reset, existing_reset, :second) >
+      @usage_reset_forward_tolerance_seconds and
+      remaining_seconds > 0 and
+      remaining_seconds <= window_seconds + @usage_reset_forward_tolerance_seconds
+  end
+
+  defp saved_reset_forward_weekly_cycle?(_evidence, _existing), do: false
+
+  defp saved_reset_precedes_transition?(
+         %Quota.AccountQuotaWindow{},
+         %Evidence{observed_at: %DateTime{} = incoming_observed_at},
+         %DateTime{} = started_at,
+         %DateTime{} = confirmed_at,
+         %DateTime{} = timestamp
+       ) do
+    corroboration_age_seconds = DateTime.diff(timestamp, confirmed_at, :second)
+
+    DateTime.compare(started_at, confirmed_at) != :gt and
+      DateTime.compare(confirmed_at, timestamp) != :gt and
+      DateTime.compare(incoming_observed_at, confirmed_at) != :lt and
+      corroboration_age_seconds >= 0 and
+      corroboration_age_seconds <= @saved_reset_corroboration_max_age_seconds
+  end
+
+  defp saved_reset_precedes_transition?(
+         _existing,
+         _evidence,
+         _started_at,
+         _confirmed_at,
+         _timestamp
+       ),
+       do: false
+
+  defp runtime_evidence_after_saved_reset?(
+         %Evidence{} = evidence,
+         %Quota.AccountQuotaWindow{upstream_identity_id: identity_id},
+         %DateTime{} = confirmed_at,
+         %DateTime{} = timestamp
+       )
+       when is_binary(identity_id) do
+    Repo.exists?(
+      from window in Quota.AccountQuotaWindow,
+        where: window.upstream_identity_id == ^identity_id,
+        where: window.source in ^@runtime_quota_sources,
+        where: window.quota_key == ^evidence.quota_key,
+        where: fragment("COALESCE(?, 'account')", window.quota_scope) == ^evidence.quota_scope,
+        where: fragment("COALESCE(?, 'account')", window.quota_family) == ^evidence.quota_family,
+        where: fragment("COALESCE(lower(?), '')", window.model) == ^lower_string(evidence.model),
+        where:
+          fragment("COALESCE(lower(?), '')", window.upstream_model) ==
+            ^lower_string(evidence.upstream_model),
+        where: window.window_kind == ^evidence.window_kind,
+        where: window.window_minutes == ^evidence.window_minutes,
+        where: window.observed_at >= ^confirmed_at and window.observed_at <= ^timestamp
+    )
+  end
+
+  defp runtime_evidence_after_saved_reset?(
+         _evidence,
+         _existing,
+         _confirmed_at,
+         _timestamp
+       ),
+       do: false
 
   # A usage-endpoint zero must never re-enable exhausted weekly quota on its
   # own: without this chokepoint guard, an expired or stale canonical takes

--- a/lib/codex_pooler/upstreams/reconciliation/pool_reconciliation.ex
+++ b/lib/codex_pooler/upstreams/reconciliation/pool_reconciliation.ex
@@ -266,7 +266,7 @@ defmodule CodexPooler.Upstreams.Reconciliation.PoolReconciliation do
             observed_at,
             usage_url,
             covered_descriptors,
-            false
+            broadcast?: false
           )
         end)
         |> case do
@@ -288,7 +288,7 @@ defmodule CodexPooler.Upstreams.Reconciliation.PoolReconciliation do
           observed_at,
           usage_url,
           covered_descriptors,
-          true
+          broadcast?: true
         )
       end
 
@@ -331,10 +331,18 @@ defmodule CodexPooler.Upstreams.Reconciliation.PoolReconciliation do
         opts \\ []
       ) do
     observed_at = now()
+    probe_opts = Keyword.drop(opts, [:weekly_restart_corroboration])
+    weekly_restart_corroboration = Keyword.get(opts, :weekly_restart_corroboration)
 
-    case UsageProbe.fetch_from_identity(identity, assignment, observed_at, opts) do
+    case UsageProbe.fetch_from_identity(identity, assignment, observed_at, probe_opts) do
       {:ok, %UsageProbe.Result{credential_fence: fence} = probe} when not is_nil(fence) ->
-        apply_refresh_usage_success(identity, probe, observed_at, fence)
+        apply_refresh_usage_success(
+          identity,
+          probe,
+          observed_at,
+          fence,
+          weekly_restart_corroboration
+        )
 
       {:error, {:definitive_provider_auth_rejected, fence}} ->
         apply_refresh_usage_rejection(identity, fence)
@@ -344,7 +352,13 @@ defmodule CodexPooler.Upstreams.Reconciliation.PoolReconciliation do
     end
   end
 
-  defp apply_refresh_usage_success(identity, probe, observed_at, fence) do
+  defp apply_refresh_usage_success(
+         identity,
+         probe,
+         observed_at,
+         fence,
+         weekly_restart_corroboration
+       ) do
     CredentialFencing.apply_usage_success(identity, fence, fn locked_identity ->
       persist_reconciliation_quota(
         locked_identity,
@@ -354,7 +368,8 @@ defmodule CodexPooler.Upstreams.Reconciliation.PoolReconciliation do
         observed_at,
         probe.usage_url,
         probe.covered_descriptors,
-        false
+        broadcast?: false,
+        weekly_restart_corroboration: weekly_restart_corroboration
       )
     end)
     |> case do
@@ -380,13 +395,22 @@ defmodule CodexPooler.Upstreams.Reconciliation.PoolReconciliation do
          observed_at,
          usage_url,
          covered_descriptors,
-         broadcast?
+         opts
        ) do
+    broadcast? = Keyword.fetch!(opts, :broadcast?)
+
+    weekly_restart_corroboration =
+      validate_saved_reset_weekly_restart_corroboration(
+        identity,
+        Keyword.get(opts, :weekly_restart_corroboration)
+      ) || saved_reset_weekly_restart_corroboration(identity)
+
     case Quota.Windows.upsert_quota_windows(identity, windows,
            delete_missing?: true,
            covered_descriptors: covered_descriptors,
            identity_attrs: identity_attrs,
-           broadcast?: broadcast?
+           broadcast?: broadcast?,
+           weekly_restart_corroboration: weekly_restart_corroboration
          ) do
       {:ok, refreshed} ->
         if is_map(payload), do: maybe_update_identity_plan(identity, payload)
@@ -421,6 +445,91 @@ defmodule CodexPooler.Upstreams.Reconciliation.PoolReconciliation do
 
   defp maybe_update_saved_reset_snapshot(identity, _payload, _observed_at, _usage_url),
     do: identity
+
+  defp saved_reset_weekly_restart_corroboration(%UpstreamIdentity{metadata: metadata} = identity) do
+    with current_epoch when is_integer(current_epoch) and current_epoch > 0 <-
+           CredentialFencing.credential_epoch(identity),
+         %{"started_at" => started_at} = redemption <-
+           (metadata || %{})["saved_reset_redemption"],
+         {:ok, ^current_epoch} <- redemption_credential_epoch(redemption, current_epoch),
+         {:ok, %DateTime{} = started_at} <- parse_redemption_datetime(started_at),
+         {:ok, %DateTime{} = confirmed_at} <- provider_confirmation_time(redemption) do
+      {:saved_reset_redemption, current_epoch, started_at, confirmed_at}
+    else
+      _redemption -> nil
+    end
+  end
+
+  defp validate_saved_reset_weekly_restart_corroboration(
+         %UpstreamIdentity{} = identity,
+         {:saved_reset_redemption, credential_epoch, %DateTime{} = started_at,
+          %DateTime{} = confirmed_at} = corroboration
+       )
+       when is_integer(credential_epoch) and credential_epoch > 0 do
+    if CredentialFencing.current_credential_epoch?(identity, credential_epoch) and
+         DateTime.compare(started_at, confirmed_at) != :gt do
+      corroboration
+    end
+  end
+
+  defp validate_saved_reset_weekly_restart_corroboration(_identity, _corroboration), do: nil
+
+  defp redemption_credential_epoch(%{"credential_epoch" => credential_epoch}, _current_epoch)
+       when is_integer(credential_epoch) and credential_epoch > 0,
+       do: {:ok, credential_epoch}
+
+  # Compatibility for saved-reset successes written before credential epochs
+  # were attached to redemption metadata. Epoch one has never crossed a
+  # credential replacement boundary; later epochs must always match explicitly.
+  defp redemption_credential_epoch(
+         %{
+           "status" => "succeeded",
+           "result" => %{"applied" => true, "code" => "reset"}
+         },
+         1
+       ),
+       do: {:ok, 1}
+
+  defp redemption_credential_epoch(_redemption, _current_epoch), do: :error
+
+  defp provider_confirmation_time(%{
+         "status" => "redeeming",
+         "provider_confirmed_at" => provider_confirmed_at
+       }) do
+    parse_redemption_datetime(provider_confirmed_at)
+  end
+
+  defp provider_confirmation_time(%{
+         "result" => %{"provider_confirmed_at" => provider_confirmed_at}
+       })
+       when is_binary(provider_confirmed_at) do
+    parse_redemption_datetime(provider_confirmed_at)
+  end
+
+  # Compatibility for successful redemptions persisted before the explicit
+  # provider confirmation timestamp was introduced. Their completion time is
+  # a conservative upper bound for the already-finished consume response.
+  defp provider_confirmation_time(%{
+         "status" => "succeeded",
+         "finished_at" => finished_at,
+         "result" => %{"applied" => true, "code" => "reset"}
+       }) do
+    parse_redemption_datetime(finished_at)
+  end
+
+  defp provider_confirmation_time(_redemption), do: :error
+
+  defp parse_redemption_datetime(datetime) when is_binary(datetime) do
+    case DateTime.from_iso8601(datetime) do
+      {:ok, %DateTime{} = parsed, _offset} ->
+        {:ok, DateTime.truncate(parsed, :microsecond)}
+
+      _invalid ->
+        :error
+    end
+  end
+
+  defp parse_redemption_datetime(_datetime), do: :error
 
   defp metadata_quota_windows(identity, assignment) do
     identity_windows = Quota.Windows.quota_windows_from_metadata(identity.metadata)

--- a/lib/codex_pooler/upstreams/saved_resets/redemption.ex
+++ b/lib/codex_pooler/upstreams/saved_resets/redemption.ex
@@ -10,6 +10,7 @@ defmodule CodexPooler.Upstreams.SavedResetRedemption do
   alias CodexPooler.Upstreams.Assignments.PoolAssignments
   alias CodexPooler.Upstreams.CloudflareCookies
   alias CodexPooler.Upstreams.EndpointMetadata
+  alias CodexPooler.Upstreams.Lifecycle.CredentialFencing
   alias CodexPooler.Upstreams.Reconciliation.PoolReconciliation
   alias CodexPooler.Upstreams.SavedResets
   alias CodexPooler.Upstreams.SavedResets.AutoEligibility
@@ -36,6 +37,7 @@ defmodule CodexPooler.Upstreams.SavedResetRedemption do
           optional(:available_count_before) => non_neg_integer(),
           optional(:available_count_after) => non_neg_integer(),
           optional(:http_status) => non_neg_integer(),
+          optional(:provider_confirmed_at) => DateTime.t(),
           optional(:reason) => String.t()
         }
 
@@ -59,6 +61,7 @@ defmodule CodexPooler.Upstreams.SavedResetRedemption do
           required(:assignment) => PoolUpstreamAssignment.t(),
           required(:attempt_id) => Ecto.UUID.t(),
           required(:generation) => non_neg_integer(),
+          required(:credential_epoch) => pos_integer(),
           required(:trigger_kind) => trigger_kind(),
           required(:started_at) => DateTime.t(),
           required(:receive_timeout) => non_neg_integer()
@@ -333,12 +336,14 @@ defmodule CodexPooler.Upstreams.SavedResetRedemption do
        ) do
     attempt_id = Ecto.UUID.generate()
     generation = next_generation(metadata)
+    credential_epoch = CredentialFencing.credential_epoch(locked_identity)
 
     claimed_identity =
       update_redemption_metadata!(locked_identity, metadata, %{
         "status" => "redeeming",
         "attempt_id" => attempt_id,
         "generation" => generation,
+        "credential_epoch" => credential_epoch,
         "trigger_kind" => trigger_kind,
         "started_at" => DateTime.to_iso8601(started_at),
         "finished_at" => nil,
@@ -350,6 +355,7 @@ defmodule CodexPooler.Upstreams.SavedResetRedemption do
       assignment: assignment,
       attempt_id: attempt_id,
       generation: generation,
+      credential_epoch: credential_epoch,
       trigger_kind: trigger_kind,
       started_at: started_at,
       receive_timeout: receive_timeout
@@ -537,8 +543,16 @@ defmodule CodexPooler.Upstreams.SavedResetRedemption do
   defp result_from_response(code, status, available_count_before, identity, assignment, claim) do
     cond do
       code == "reset" ->
-        case PoolReconciliation.refresh_quota_from_usage(identity, assignment,
-               receive_timeout: claim.receive_timeout
+        provider_confirmed_at = now()
+
+        confirmed_identity =
+          record_provider_reset_confirmation(identity, claim, provider_confirmed_at)
+
+        case PoolReconciliation.refresh_quota_from_usage(confirmed_identity, assignment,
+               receive_timeout: claim.receive_timeout,
+               weekly_restart_corroboration:
+                 {:saved_reset_redemption, claim.credential_epoch, claim.started_at,
+                  provider_confirmed_at}
              ) do
           {:ok, refreshed_identity} ->
             available_count_after = SavedResets.snapshot(refreshed_identity).available_count
@@ -549,7 +563,8 @@ defmodule CodexPooler.Upstreams.SavedResetRedemption do
               code: code,
               available_count_before: available_count_before,
               available_count_after: available_count_after,
-              http_status: status
+              http_status: status,
+              provider_confirmed_at: provider_confirmed_at
             }
 
           {:error, _reason} ->
@@ -559,6 +574,7 @@ defmodule CodexPooler.Upstreams.SavedResetRedemption do
               code: "post_reset_usage_refresh_failed",
               available_count_before: available_count_before,
               http_status: status,
+              provider_confirmed_at: provider_confirmed_at,
               reason: "quota refresh after saved reset failed"
             }
         end
@@ -582,6 +598,44 @@ defmodule CodexPooler.Upstreams.SavedResetRedemption do
           reason: "saved reset redemption failed"
         }
     end
+  end
+
+  # Publish the provider confirmation before starting the usage refresh. A
+  # scheduled probe may be allocated after this refresh and win the credential
+  # fence; persisting the marker lets that winning probe apply the same bounded
+  # corroboration instead of quarantining the provider's zero again.
+  defp record_provider_reset_confirmation(identity, claim, provider_confirmed_at) do
+    Repo.transaction(fn ->
+      locked_identity = lock_identity!(identity.id)
+      metadata = locked_identity.metadata || %{}
+      redemption = metadata["saved_reset_redemption"] || %{}
+
+      if current_provider_confirmation_claim?(redemption, locked_identity, claim) do
+        update_redemption_metadata!(
+          locked_identity,
+          metadata,
+          Map.put(
+            redemption,
+            "provider_confirmed_at",
+            DateTime.to_iso8601(provider_confirmed_at)
+          )
+        )
+      else
+        locked_identity
+      end
+    end)
+    |> case do
+      {:ok, confirmed_identity} -> confirmed_identity
+      {:error, _reason} -> identity
+    end
+  end
+
+  defp current_provider_confirmation_claim?(redemption, locked_identity, claim) do
+    redemption["status"] == "redeeming" and
+      redemption["attempt_id"] == claim.attempt_id and
+      redemption["generation"] == claim.generation and
+      redemption["credential_epoch"] == claim.credential_epoch and
+      CredentialFencing.credential_epoch(locked_identity) == claim.credential_epoch
   end
 
   defp response_code(body, status, endpoint_kind) do
@@ -681,7 +735,9 @@ defmodule CodexPooler.Upstreams.SavedResetRedemption do
       redemption = metadata["saved_reset_redemption"] || %{}
 
       if redemption["attempt_id"] == claim.attempt_id and
-           redemption["generation"] == claim.generation do
+           redemption["generation"] == claim.generation and
+           redemption["credential_epoch"] == claim.credential_epoch and
+           CredentialFencing.credential_epoch(identity) == claim.credential_epoch do
         finished_at = now()
         final_status = Atom.to_string(result.status)
 
@@ -690,6 +746,7 @@ defmodule CodexPooler.Upstreams.SavedResetRedemption do
             "status" => final_status,
             "attempt_id" => claim.attempt_id,
             "generation" => claim.generation,
+            "credential_epoch" => claim.credential_epoch,
             "trigger_kind" => claim.trigger_kind,
             "started_at" => DateTime.to_iso8601(claim.started_at),
             "finished_at" => DateTime.to_iso8601(finished_at),
@@ -723,7 +780,13 @@ defmodule CodexPooler.Upstreams.SavedResetRedemption do
       "available_count_after" => Map.get(result, :available_count_after),
       "http_status" => Map.get(result, :http_status)
     }
+    |> maybe_put_provider_confirmed_at(Map.get(result, :provider_confirmed_at))
   end
+
+  defp maybe_put_provider_confirmed_at(result, %DateTime{} = datetime),
+    do: Map.put(result, "provider_confirmed_at", DateTime.to_iso8601(datetime))
+
+  defp maybe_put_provider_confirmed_at(result, _datetime), do: result
 
   defp noop_result(identity, assignment, code) when is_binary(code) do
     %{

--- a/test/codex_pooler/upstreams/saved_reset_redemption_test.exs
+++ b/test/codex_pooler/upstreams/saved_reset_redemption_test.exs
@@ -6,6 +6,7 @@ defmodule CodexPooler.Upstreams.SavedResetRedemptionTest do
   alias CodexPooler.FakeUpstream
   alias CodexPooler.Repo
   alias CodexPooler.Upstreams.Quota.Windows, as: QuotaWindows
+  alias CodexPooler.Upstreams.Reconciliation.PoolReconciliation
   alias CodexPooler.Upstreams.SavedResetRedemption
   alias CodexPooler.Upstreams.SavedResets.AutoEligibility
   alias CodexPooler.Upstreams.Schemas.{PoolUpstreamAssignment, UpstreamIdentity}
@@ -56,6 +57,15 @@ defmodule CodexPooler.Upstreams.SavedResetRedemptionTest do
 
       persisted = Repo.reload!(identity)
       assert get_in(persisted.metadata, ["saved_reset_redemption", "result", "code"]) == "reset"
+
+      assert is_binary(
+               get_in(persisted.metadata, [
+                 "saved_reset_redemption",
+                 "result",
+                 "provider_confirmed_at"
+               ])
+             )
+
       metadata_json = Jason.encode!(persisted.metadata)
       refute metadata_json =~ "credit_1"
       refute metadata_json =~ redeem_request_id
@@ -86,6 +96,304 @@ defmodule CodexPooler.Upstreams.SavedResetRedemptionTest do
       assert %{"redeem_request_id" => redeem_request_id} = body
       assert is_binary(redeem_request_id)
       refute Map.has_key?(body, "credit_id")
+    end
+
+    test "confirmed redemption replaces exhausted weekly usage and restores routing" do
+      observed_at = DateTime.utc_now() |> DateTime.truncate(:second)
+      previous_reset_at = DateTime.add(observed_at, 5, :day)
+      restarted_reset_at = DateTime.add(observed_at, 7, :day)
+
+      {:ok, fake} =
+        FakeUpstream.start_link(
+          {:path_json,
+           %{
+             "/api/codex/rate-limit-reset-credits/consume" => {200, %{"code" => "reset"}},
+             "/api/codex/usage" =>
+               {200,
+                usage_payload(0,
+                  secondary_window: %{
+                    "used_percent" => 0,
+                    "limit_window_seconds" => 604_800,
+                    "reset_at" => DateTime.to_iso8601(restarted_reset_at)
+                  }
+                )}
+           }}
+        )
+
+      %{identity: identity, assignment: assignment} =
+        assignment_with_fake(fake, "/api/codex/usage", "codex_api")
+
+      for source <- ["codex_usage_api", "codex_response_headers", "codex_rate_limit_event"] do
+        upsert_weekly_exhausted_quota!(identity,
+          source: source,
+          reset_at: previous_reset_at,
+          observed_at: observed_at,
+          last_sync_at: observed_at
+        )
+      end
+
+      assert %{eligible?: false, routing_state: :blocked} =
+               QuotaWindows.routing_quota_eligibility(identity, at: observed_at)
+
+      assert {:ok, %{status: :succeeded, applied?: true, code: "reset"}} =
+               SavedResetRedemption.redeem(assignment)
+
+      weekly_usage =
+        identity
+        |> QuotaWindows.list_evidence()
+        |> Enum.find(&(&1.source == "codex_usage_api" and &1.window_kind == "secondary"))
+
+      assert Decimal.equal?(weekly_usage.used_percent, Decimal.new(0))
+      assert DateTime.compare(weekly_usage.reset_at, restarted_reset_at) == :eq
+
+      assert %{
+               eligible?: true,
+               selection: %{secondary: %{id: weekly_usage_id, source: "codex_usage_api"}}
+             } = QuotaWindows.routing_quota_eligibility(identity)
+
+      assert weekly_usage_id == weekly_usage.id
+    end
+
+    test "persisted successful redemption self-heals a pre-existing stale weekly snapshot" do
+      timestamp = DateTime.utc_now() |> DateTime.truncate(:second)
+      observed_at = DateTime.add(timestamp, -2, :minute)
+      confirmed_at = DateTime.add(timestamp, -1, :minute)
+      previous_reset_at = DateTime.add(timestamp, 5, :day)
+      restarted_reset_at = DateTime.add(timestamp, 7, :day)
+
+      {:ok, fake} = weekly_zero_usage_fake(restarted_reset_at)
+
+      %{identity: identity, assignment: assignment} =
+        assignment_with_fake(fake, "/api/codex/usage", "codex_api")
+
+      for source <- ["codex_usage_api", "codex_response_headers", "codex_rate_limit_event"] do
+        upsert_weekly_exhausted_quota!(identity,
+          source: source,
+          reset_at: previous_reset_at,
+          observed_at: observed_at,
+          last_sync_at: observed_at
+        )
+      end
+
+      redeemed_identity =
+        update_redemption!(identity, succeeded_redemption_metadata(confirmed_at))
+
+      assert {:ok, _identity} =
+               PoolReconciliation.refresh_quota_from_usage(redeemed_identity, assignment)
+
+      weekly_usage = usage_weekly_evidence(redeemed_identity)
+
+      assert Decimal.equal?(weekly_usage.used_percent, Decimal.new(0))
+      assert DateTime.compare(weekly_usage.reset_at, restarted_reset_at) == :eq
+      assert %{eligible?: true} = QuotaWindows.routing_quota_eligibility(redeemed_identity)
+    end
+
+    test "a provider-confirmed in-progress redemption lets the newer concurrent probe converge" do
+      timestamp = DateTime.utc_now() |> DateTime.truncate(:second)
+      observed_at = DateTime.add(timestamp, -3, :minute)
+      started_at = DateTime.add(timestamp, -2, :minute)
+      confirmed_at = DateTime.add(timestamp, -1, :minute)
+      previous_reset_at = DateTime.add(timestamp, 5, :day)
+      restarted_reset_at = DateTime.add(timestamp, 7, :day)
+
+      {:ok, fake} = weekly_zero_usage_fake(restarted_reset_at)
+
+      %{identity: identity, assignment: assignment} =
+        assignment_with_fake(fake, "/api/codex/usage", "codex_api")
+
+      upsert_weekly_exhausted_quota!(identity,
+        reset_at: previous_reset_at,
+        observed_at: observed_at,
+        last_sync_at: observed_at
+      )
+
+      confirmed_identity =
+        update_redemption!(
+          identity,
+          provider_confirmed_in_progress_metadata(started_at, confirmed_at)
+        )
+
+      # This is the deterministic form of the fence race: a scheduled probe
+      # that was allocated after the redemption refresh may apply first. It
+      # sees the persisted in-progress provider confirmation while holding the
+      # identity lock and is therefore able to converge the weekly snapshot.
+      assert {:ok, _identity} =
+               PoolReconciliation.refresh_quota_from_usage(confirmed_identity, assignment)
+
+      assert Decimal.equal?(
+               usage_weekly_evidence(confirmed_identity).used_percent,
+               Decimal.new(0)
+             )
+
+      assert %{eligible?: true} = QuotaWindows.routing_quota_eligibility(confirmed_identity)
+    end
+
+    test "provider confirmation supersedes runtime evidence observed while consume was in flight" do
+      timestamp = DateTime.utc_now() |> DateTime.truncate(:second)
+      observed_at = DateTime.add(timestamp, -4, :minute)
+      started_at = DateTime.add(timestamp, -3, :minute)
+      runtime_at = DateTime.add(timestamp, -2, :minute)
+      confirmed_at = DateTime.add(timestamp, -1, :minute)
+      previous_reset_at = DateTime.add(timestamp, 5, :day)
+      restarted_reset_at = DateTime.add(timestamp, 7, :day)
+
+      {:ok, fake} = weekly_zero_usage_fake(restarted_reset_at)
+
+      %{identity: identity, assignment: assignment} =
+        assignment_with_fake(fake, "/api/codex/usage", "codex_api")
+
+      upsert_weekly_exhausted_quota!(identity,
+        reset_at: previous_reset_at,
+        observed_at: observed_at,
+        last_sync_at: observed_at
+      )
+
+      confirmed_identity =
+        update_redemption!(
+          identity,
+          provider_confirmed_in_progress_metadata(started_at, confirmed_at)
+        )
+
+      upsert_weekly_exhausted_quota!(confirmed_identity,
+        source: "codex_rate_limit_event",
+        reset_at: previous_reset_at,
+        observed_at: runtime_at,
+        last_sync_at: runtime_at
+      )
+
+      assert {:ok, _identity} =
+               PoolReconciliation.refresh_quota_from_usage(confirmed_identity, assignment)
+
+      assert Decimal.equal?(
+               usage_weekly_evidence(confirmed_identity).used_percent,
+               Decimal.new(0)
+             )
+
+      assert %{eligible?: true} =
+               QuotaWindows.routing_quota_eligibility(confirmed_identity)
+    end
+
+    test "lagging old-cycle usage cannot strand a confirmed reset zero" do
+      timestamp = DateTime.utc_now() |> DateTime.truncate(:second)
+      observed_at = DateTime.add(timestamp, -4, :minute)
+      confirmed_at = DateTime.add(timestamp, -2, :minute)
+      lagging_at = DateTime.add(timestamp, -1, :minute)
+      previous_reset_at = DateTime.add(timestamp, 5, :day)
+      restarted_reset_at = DateTime.add(timestamp, 7, :day)
+
+      {:ok, fake} = weekly_zero_usage_fake(restarted_reset_at)
+
+      %{identity: identity, assignment: assignment} =
+        assignment_with_fake(fake, "/api/codex/usage", "codex_api")
+
+      upsert_weekly_exhausted_quota!(identity,
+        reset_at: previous_reset_at,
+        observed_at: observed_at,
+        last_sync_at: observed_at
+      )
+
+      redeemed_identity =
+        update_redemption!(identity, succeeded_redemption_metadata(confirmed_at))
+
+      upsert_weekly_exhausted_quota!(redeemed_identity,
+        reset_at: previous_reset_at,
+        observed_at: lagging_at,
+        last_sync_at: lagging_at
+      )
+
+      assert DateTime.compare(usage_weekly_evidence(redeemed_identity).observed_at, lagging_at) ==
+               :eq
+
+      assert {:ok, _identity} =
+               PoolReconciliation.refresh_quota_from_usage(redeemed_identity, assignment)
+
+      weekly_usage = usage_weekly_evidence(redeemed_identity)
+      assert Decimal.equal?(weekly_usage.used_percent, Decimal.new(0))
+      assert DateTime.compare(weekly_usage.reset_at, restarted_reset_at) == :eq
+      assert %{eligible?: true} = QuotaWindows.routing_quota_eligibility(redeemed_identity)
+    end
+
+    test "redemption from an earlier credential epoch cannot clear current quota" do
+      timestamp = DateTime.utc_now() |> DateTime.truncate(:second)
+      observed_at = DateTime.add(timestamp, -3, :minute)
+      confirmed_at = DateTime.add(timestamp, -2, :minute)
+      previous_reset_at = DateTime.add(timestamp, 5, :day)
+      restarted_reset_at = DateTime.add(timestamp, 7, :day)
+
+      {:ok, fake} = weekly_zero_usage_fake(restarted_reset_at)
+
+      %{identity: identity, assignment: assignment} =
+        assignment_with_fake(fake, "/api/codex/usage", "codex_api")
+
+      upsert_weekly_exhausted_quota!(identity,
+        reset_at: previous_reset_at,
+        observed_at: observed_at,
+        last_sync_at: observed_at
+      )
+
+      current_identity =
+        update_identity!(identity, %{
+          metadata: Map.put(identity.metadata || %{}, "credential_epoch", 2)
+        })
+
+      stale_redemption =
+        confirmed_at
+        |> succeeded_redemption_metadata()
+        |> Map.put("credential_epoch", 1)
+
+      current_identity = update_redemption!(current_identity, stale_redemption)
+
+      assert {:ok, _identity} =
+               PoolReconciliation.refresh_quota_from_usage(current_identity, assignment)
+
+      assert Decimal.equal?(
+               usage_weekly_evidence(current_identity).used_percent,
+               Decimal.new(100)
+             )
+
+      assert %{eligible?: false, routing_state: :blocked} =
+               QuotaWindows.routing_quota_eligibility(current_identity)
+    end
+
+    test "post-redemption runtime evidence prevents stale success from authorizing a later zero" do
+      timestamp = DateTime.utc_now() |> DateTime.truncate(:second)
+      observed_at = DateTime.add(timestamp, -3, :minute)
+      confirmed_at = DateTime.add(timestamp, -2, :minute)
+      runtime_at = DateTime.add(timestamp, -1, :minute)
+      previous_reset_at = DateTime.add(timestamp, 5, :day)
+      restarted_reset_at = DateTime.add(timestamp, 7, :day)
+
+      {:ok, fake} = weekly_zero_usage_fake(restarted_reset_at)
+
+      %{identity: identity, assignment: assignment} =
+        assignment_with_fake(fake, "/api/codex/usage", "codex_api")
+
+      upsert_weekly_exhausted_quota!(identity,
+        reset_at: previous_reset_at,
+        observed_at: observed_at,
+        last_sync_at: observed_at
+      )
+
+      redeemed_identity =
+        update_redemption!(identity, succeeded_redemption_metadata(confirmed_at))
+
+      upsert_weekly_exhausted_quota!(redeemed_identity,
+        source: "codex_rate_limit_event",
+        reset_at: previous_reset_at,
+        observed_at: runtime_at,
+        last_sync_at: runtime_at
+      )
+
+      assert {:ok, _identity} =
+               PoolReconciliation.refresh_quota_from_usage(redeemed_identity, assignment)
+
+      assert Decimal.equal?(
+               usage_weekly_evidence(redeemed_identity).used_percent,
+               Decimal.new(100)
+             )
+
+      assert %{eligible?: false, routing_state: :blocked} =
+               QuotaWindows.routing_quota_eligibility(redeemed_identity)
     end
 
     test "does not consume when no ChatGPT credit is usable and preserves expiration metadata" do
@@ -570,6 +878,23 @@ defmodule CodexPooler.Upstreams.SavedResetRedemptionTest do
     )
   end
 
+  defp weekly_zero_usage_fake(restarted_reset_at) do
+    FakeUpstream.start_link(
+      {:path_json,
+       %{
+         "/api/codex/usage" =>
+           {200,
+            usage_payload(0,
+              secondary_window: %{
+                "used_percent" => 0,
+                "limit_window_seconds" => 604_800,
+                "reset_at" => DateTime.to_iso8601(restarted_reset_at)
+              }
+            )}
+       }}
+    )
+  end
+
   defp assignment_with_fake(fake, usage_path, path_style, opts \\ []) do
     saved_resets =
       Keyword.get(opts, :saved_resets, %{
@@ -712,6 +1037,44 @@ defmodule CodexPooler.Upstreams.SavedResetRedemptionTest do
     }
   end
 
+  defp succeeded_redemption_metadata(finished_at) do
+    %{
+      "status" => "succeeded",
+      "attempt_id" => Ecto.UUID.generate(),
+      "generation" => 1,
+      "trigger_kind" => "admin_manual",
+      "started_at" => finished_at |> DateTime.add(-5, :second) |> DateTime.to_iso8601(),
+      "finished_at" => DateTime.to_iso8601(finished_at),
+      "result" => %{
+        "code" => "reset",
+        "applied" => true,
+        "available_count_before" => 1,
+        "available_count_after" => 0,
+        "http_status" => 200
+      }
+    }
+  end
+
+  defp provider_confirmed_in_progress_metadata(started_at, confirmed_at) do
+    %{
+      "status" => "redeeming",
+      "attempt_id" => Ecto.UUID.generate(),
+      "generation" => 1,
+      "credential_epoch" => 1,
+      "trigger_kind" => "admin_manual",
+      "started_at" => DateTime.to_iso8601(started_at),
+      "finished_at" => nil,
+      "provider_confirmed_at" => DateTime.to_iso8601(confirmed_at),
+      "result" => nil
+    }
+  end
+
+  defp usage_weekly_evidence(identity) do
+    identity
+    |> QuotaWindows.list_evidence()
+    |> Enum.find(&(&1.source == "codex_usage_api" and &1.window_kind == "secondary"))
+  end
+
   defp upsert_weekly_exhausted_quota!(identity, overrides \\ []) do
     assert {:ok, [_window]} =
              QuotaWindows.upsert_quota_windows(identity, [
@@ -746,8 +1109,8 @@ defmodule CodexPooler.Upstreams.SavedResetRedemptionTest do
     )
   end
 
-  defp usage_payload(available_count) do
-    %{
+  defp usage_payload(available_count, opts \\ []) do
+    payload = %{
       "plan_type" => "pro",
       "rate_limit_reset_credits" => %{"available_count" => available_count},
       "rate_limit" => %{
@@ -758,5 +1121,13 @@ defmodule CodexPooler.Upstreams.SavedResetRedemptionTest do
         }
       }
     }
+
+    case Keyword.get(opts, :secondary_window) do
+      %{} = secondary_window ->
+        put_in(payload, ["rate_limit", "secondary_window"], secondary_window)
+
+      _secondary_window ->
+        payload
+    end
   end
 end


### PR DESCRIPTION
## Summary

This fixes the saved-reset state divergence where the provider accepts a reset credit, but codex-pooler keeps the account's canonical weekly quota evidence at `100%` and therefore leaves routing blocked.

The change:

- treats a successful saved-reset consume response as bounded, independent corroboration for the immediately following weekly usage snapshot;
- publishes the provider confirmation before the usage refresh so a newer concurrent reconciliation probe can converge the same state;
- binds that confirmation to the redemption attempt, generation, and credential epoch;
- repairs already-stale successful redemptions during ordinary scheduled reconciliation without manual SQL;
- keeps the existing fail-closed rule for ordinary usage-endpoint zeroes and for any contradictory runtime evidence observed after the provider confirmation.

Related to #146 and the zero-percent guard introduced in `e487d18f`. This branch is based directly on current `main` (`b628d7ea`) and preserves the credential-fencing work in `c6ea3cac` and `ff289f52`.

## Production failure mode

The observed sequence is:

1. An account has exhausted account-scoped weekly (`secondary`, 10,080-minute) evidence.
2. A saved-reset redemption claims and consumes a provider credit.
3. The provider responds successfully (`HTTP 200`, `code: reset`, `applied: true`) and the available credit count decreases.
4. The immediate usage refresh reports the new weekly cycle at `0%`.
5. `EvidenceStore` classifies that as an uncorroborated `100% -> 0%` transition and preserves the exhausted row.
6. The redemption still finalizes successfully because evidence rejection is represented as retaining the existing row, not as a persistence error.
7. Later scheduled probes repeat the same rejection, so the row's maintenance timestamp can advance while its canonical observation remains stale and routing stays blocked.

The provider-side reset and banked-reset consumption therefore succeeded; the stale state was in local quota convergence, not in redemption execution.

## Root cause

The existing zero-percent guard is intentionally conservative: one usage-endpoint zero must not re-enable an exhausted weekly account without an independent signal. That protects routing from incomplete, lagging, or temporarily removed provider fields.

A successful saved-reset consume response is exactly such an independent signal, but that causal context stopped at `SavedResetRedemption`. The following `PoolReconciliation` usage refresh reached `Quota.Windows` and `EvidenceStore` as an ordinary probe, so the guard could not distinguish a confirmed reset from an unsafe lone zero.

There were also three ordering hazards to address rather than simply bypassing the guard:

### 1. Usage-probe sequence race

A redemption refresh can allocate usage probe sequence `N`, while scheduled reconciliation allocates `N+1`. If `N+1` applies first, the existing credential fence correctly supersedes `N`. An in-memory reset flag attached only to `N` would be lost, and the winning probe would quarantine the zero again.

The fix records `provider_confirmed_at` on the in-progress redemption before starting the refresh. Any winning same-epoch probe reads that marker while holding the credential-fencing identity lock and can apply the same bounded corroboration.

### 2. Credential-relink race

A reset request can be sent with credential epoch `E`, followed by a concurrent relink to epoch `E+1`. The old provider response must never authorize quota returned under the new credentials.

The redemption claim now captures its credential epoch. Provider confirmation, finalization, explicit refresh context, and persisted repair all require that epoch to match the currently locked identity. A mismatched confirmation is ignored and normal fail-closed quota handling remains in force.

### 3. Late old-cycle usage race

A lagging `100%` usage response can be observed or persisted after provider confirmation but still describe the old reset cycle. If acceptance depends on the existing row's `observed_at` predating the redemption, that late write can strand the later valid `0%` indefinitely.

The fix keys the transition to a causally newer provider confirmation plus an explicit forward weekly reset boundary. A late old-cycle usage row cannot strand the new cycle. Conversely, a `100%` observation already carrying the new cycle's reset boundary is not cleared by the exception.

## Safety constraints

The reset-specific path is deliberately narrower than the normal merge logic. It applies only when all of the following are true:

- the incoming source is `codex_usage_api`;
- the evidence is account-scoped weekly quota (`secondary`, 10,080 minutes);
- the evidence identity dimensions match the existing canonical row;
- the existing row is exhausted and the incoming value is exactly `0%`;
- the incoming snapshot is fresh, unexpired, reset-bearing, and observed after provider confirmation;
- the incoming reset boundary advances beyond the old boundary by more than the existing tolerance and remains plausible for a weekly window;
- the redemption claim began no later than provider confirmation;
- the confirmation is no more than 24 hours old;
- the redemption credential epoch matches the currently locked identity;
- no independent runtime evidence (`codex_response_headers`, `codex_rate_limit_event`, or `codex_rate_limit_error`) for the same logical window was observed at or after confirmation.

Quota evidence writes remain serialized by the existing per-identity PostgreSQL advisory transaction lock. Credential replacement and usage application remain serialized by `CredentialFencing`; this change passes corroboration through that locked callback instead of introducing an alternate write path.

Ordinary usage zeroes still take the existing uncorroborated-zero guard unchanged.

## Existing stale-state repair

The next successful scheduled usage reconciliation can repair an already-stale row by deriving corroboration from persisted `saved_reset_redemption` metadata.

For records written before this change:

- only `status: succeeded`, `result.applied: true`, `result.code: reset` is accepted;
- `finished_at` is used as the conservative provider-confirmation time because the provider response necessarily completed before finalization;
- missing redemption credential epochs are accepted only while the identity remains at epoch 1, so legacy repair cannot cross a credential-replacement boundary;
- the same 24-hour bound, forward-cycle check, freshness rules, and runtime-evidence veto apply.

No migration, backfill, or manual database repair is required for a recent same-epoch stale redemption. Older, contradictory, or epoch-mismatched records remain safely blocked and require new provider evidence or a new reset.

## Code changes

- `SavedResetRedemption`
  - captures credential epoch in the claim and persisted result;
  - records provider confirmation before usage refresh;
  - fences confirmation and finalization against credential replacement;
  - passes the causal reset context into reconciliation.
- `PoolReconciliation`
  - removes the internal corroboration option before provider HTTP probing;
  - carries it through the existing credential-fenced success callback;
  - validates explicit context against the locked credential epoch;
  - derives bounded context from persisted in-progress or successful redemption metadata.
- `Quota.Windows`
  - forwards only the reset-corroboration option to evidence persistence.
- `EvidenceStore`
  - accepts the narrowly defined confirmed forward weekly transition;
  - rejects post-confirmation runtime contradictions;
  - leaves the ordinary uncorroborated-zero behavior unchanged.
- `SavedResetRedemptionTest`
  - adds end-to-end and deterministic race regression coverage.

## Verification

Passing locally against PostgreSQL 18 and current `main`:

- `mix compile --warnings-as-errors`
- `mix format --check-formatted` for all five changed files
- `mix credo --strict` for all five changed files - no issues
- complete `saved_reset_redemption_test.exs` plus the surrounding weekly-zero, weekly-restart, runtime-corroboration, and auto-routing cases - **32 passed, 300 excluded**
- `git diff --check`

The focused cases verify:

- a confirmed redemption replaces exhausted usage evidence and restores routing;
- a persisted pre-change success self-heals a stale row;
- an in-progress provider confirmation is usable by a newer concurrent probe;
- pre-confirmation runtime evidence is causally superseded by provider confirmation;
- post-confirmation runtime evidence vetoes the exception;
- a late old-cycle `100%` snapshot cannot strand the later valid zero;
- an earlier credential epoch cannot clear current quota;
- ordinary lone usage zeroes still cannot re-enable exhausted weekly quota;
- saved-reset auto-routing still redeems and refilters correctly.

A full `mix dialyzer` was also attempted. The container environment terminated it at the configured 10-minute limit while it was still silent; it emitted no diagnostic before timeout. This is reported as a timeout, not as a passing type-analysis result.

## Risk and rollback

The main behavioral risk is accepting a provider-confirmed zero that later proves inconsistent. The scope and time bounds above minimize that surface, and any post-confirmation runtime contradiction keeps routing fail-closed.

Rollback is a single commit revert. There is no schema change, data migration, deployment change, UI change, or irreversible data rewrite in this PR.

## Scope

This PR intentionally contains only the saved-reset quota convergence fix and its regression tests. It does not include admin UI work, unrelated stale-state cleanup, deployment/Portainer changes, or other local workspace changes.