### PR TITLE
fix(tokenizer): accept CRLF rank files

### DIFF
--- a/lib/codex_pooler/gateway/request_compression/token_counter/ranks.ex
+++ b/lib/codex_pooler/gateway/request_compression/token_counter/ranks.ex
@@ -62,7 +62,7 @@ defmodule CodexPooler.Gateway.RequestCompression.TokenCounter.Ranks do
   end
 
   defp parse_line(line) do
-    with [encoded_token, rank_string] <- String.split(line, " ", parts: 2),
+    with [encoded_token, rank_string] <- line |> String.trim() |> String.split(" ", parts: 2),
          {:ok, token} <- Base.decode64(encoded_token),
          {rank, ""} <- Integer.parse(rank_string) do
       {:ok, token, rank}

--- a/test/codex_pooler/gateway/request_compression/token_counter/ranks_test.exs
+++ b/test/codex_pooler/gateway/request_compression/token_counter/ranks_test.exs
@@ -1,0 +1,17 @@
+defmodule CodexPooler.Gateway.RequestCompression.TokenCounter.RanksTest do
+  use ExUnit.Case, async: false
+
+  alias CodexPooler.Gateway.RequestCompression.TokenCounter.Ranks
+
+  test "loads rank files from a CRLF checkout" do
+    Enum.each(Ranks.supported_encodings(), fn encoding ->
+      cache_key = {Ranks, :ranks, encoding}
+      :persistent_term.erase(cache_key)
+
+      assert {:ok, ranks} = Ranks.load(encoding)
+      assert map_size(ranks) > 0
+
+      :persistent_term.erase(cache_key)
+    end)
+  end
+end


### PR DESCRIPTION
## Summary

- trim each tokenizer rank-file line before splitting the base64 token from its numeric rank
- make checked-in .tiktoken assets load correctly from Windows/CRLF worktrees
- add a focused regression that clears the rank cache and loads every supported encoding from the real packaged files

## Issue

The rank parser split the file on \n, then passed the untrimmed rank field directly to Integer.parse/1. In a CRLF checkout each rank ended in \r, so parsing returned {rank, "\r"} instead of {rank, ""}. The entire rank file was then classified as :invalid_rank_file, disabling local token counting even though the packaged data was valid.

This is checkout-platform dependent: LF worktrees load successfully, while the same committed asset can fail on Windows when Git materializes CRLF lines.

## Fix

Normalize each logical line with String.trim/1 before the existing two-field split. Base64 decoding, integer validation, duplicate handling, supported encodings, and persistent-term caching are unchanged.

The change is deliberately at the parser boundary rather than in callers, so release assets and development checkouts follow the same validation path.

## Verification

- dedicated CRLF rank-loader regression: **1 passed**
- the regression clears :persistent_term for both supported encodings, loads the real rank files, and asserts a non-empty rank map
- git diff --check: clean

While checking the broader tokenizer file on a Windows bind mount, its existing literal-diff oracle assertion remains line-ending-sensitive (27 expected versus 28 with CRLF source text). That assertion is unrelated to rank-file parsing; this PR's dedicated loader regression passes and isolates the fixed behavior.

## Scope

- parser normalization only
- one focused regression file
- no schema, runtime configuration, or deployment changes