### PR TITLE
feat(admin): paginate audit and request logs

### DIFF
--- a/lib/codex_pooler_web/live/admin/components/pages/audit_logs/components.ex
+++ b/lib/codex_pooler_web/live/admin/components/pages/audit_logs/components.ex
@@ -4,6 +4,7 @@ defmodule CodexPoolerWeb.Admin.AuditLogsComponents do
   use CodexPoolerWeb, :html
 
   alias CodexPoolerWeb.Admin.AuditLogsComponents.Filters
+  alias CodexPoolerWeb.Admin.LogPagination
 
   import CodexPoolerWeb.Admin.AuditLogsComponents.Presentation,
     only: [
@@ -23,6 +24,7 @@ defmodule CodexPoolerWeb.Admin.AuditLogsComponents do
   defdelegate audit_log_filters(assigns), to: Filters
 
   attr :audit_logs, :map, required: true
+  attr :current_params, :map, required: true
   attr :datetime_preferences, :map, required: true
 
   def audit_logs_table(assigns) do
@@ -31,6 +33,17 @@ defmodule CodexPoolerWeb.Admin.AuditLogsComponents do
       id="admin-audit-logs"
       class="min-w-0 rounded-box border border-base-300 bg-base-100 shadow-sm"
     >
+      <LogPagination.controls
+        page={@audit_logs}
+        base_path="/admin/audit-logs"
+        current_params={@current_params}
+        id_prefix="admin-audit-logs-pagination-top"
+        range_id="admin-audit-logs-range-top"
+        range_role="audit-logs-range"
+        label="Audit logs"
+        placement={:top}
+      />
+
       <div class="hidden overflow-x-auto md:block">
         <table class="table min-w-[58rem] font-sans">
           <colgroup>
@@ -243,6 +256,17 @@ defmodule CodexPoolerWeb.Admin.AuditLogsComponents do
           </caption>
         </table>
       </div>
+
+      <LogPagination.controls
+        page={@audit_logs}
+        base_path="/admin/audit-logs"
+        current_params={@current_params}
+        id_prefix="admin-audit-logs-pagination-bottom"
+        range_id="admin-audit-logs-range-bottom"
+        range_role="audit-logs-range"
+        label="Audit logs"
+        placement={:bottom}
+      />
     </div>
     """
   end

--- a/lib/codex_pooler_web/live/admin/components/pages/request_logs/presentation.ex
+++ b/lib/codex_pooler_web/live/admin/components/pages/request_logs/presentation.ex
@@ -5,6 +5,7 @@ defmodule CodexPoolerWeb.Admin.RequestLogsPresentation do
 
   alias CodexPoolerWeb.Admin.BadgeComponents, as: AdminBadges
   alias CodexPoolerWeb.Admin.Components, as: AdminComponents
+  alias CodexPoolerWeb.Admin.LogPagination
   alias CodexPoolerWeb.Admin.RequestLogsPresentation.Usage
 
   import CodexPoolerWeb.Admin.RequestLogsDisplay,
@@ -35,6 +36,7 @@ defmodule CodexPoolerWeb.Admin.RequestLogsPresentation do
     ]
 
   attr :request_logs, :map, required: true
+  attr :current_params, :map, required: true
   attr :datetime_preferences, :map, required: true
 
   def request_logs_table(assigns) do
@@ -43,7 +45,8 @@ defmodule CodexPoolerWeb.Admin.RequestLogsPresentation do
       id="admin-request-logs"
       class={[
         "min-w-0",
-        @request_logs.items != [] && "rounded-box border border-base-300 bg-base-100 shadow-sm"
+        (@request_logs.items != [] or @request_logs.total > 0) &&
+          "rounded-box border border-base-300 bg-base-100 shadow-sm"
       ]}
     >
       <AdminComponents.empty_state
@@ -52,6 +55,18 @@ defmodule CodexPoolerWeb.Admin.RequestLogsPresentation do
         title="No request logs"
         description="Send a request through a Pool or adjust the filters to find existing log rows."
         icon="hero-document-magnifying-glass"
+      />
+
+      <LogPagination.controls
+        page={@request_logs}
+        base_path="/admin/request-logs"
+        current_params={@current_params}
+        id_prefix="admin-request-logs-pagination-top"
+        range_id="admin-request-logs-range-top"
+        range_role="request-logs-range"
+        label="Request logs"
+        placement={:top}
+        show_border={@request_logs.items != []}
       />
 
       <div :if={@request_logs.items != []} class="hidden overflow-x-auto md:block">
@@ -256,6 +271,18 @@ defmodule CodexPoolerWeb.Admin.RequestLogsPresentation do
           </caption>
         </table>
       </div>
+
+      <LogPagination.controls
+        page={@request_logs}
+        base_path="/admin/request-logs"
+        current_params={@current_params}
+        id_prefix="admin-request-logs-pagination"
+        range_id="admin-request-logs-range"
+        range_role="request-logs-range"
+        label="Request logs"
+        placement={:bottom}
+        show_border={@request_logs.items != []}
+      />
     </div>
     """
   end

--- a/lib/codex_pooler_web/live/admin/log_pagination.ex
+++ b/lib/codex_pooler_web/live/admin/log_pagination.ex
@@ -1,0 +1,194 @@
+defmodule CodexPoolerWeb.Admin.LogPagination do
+  @moduledoc false
+
+  use CodexPoolerWeb, :html
+
+  @max_page 10_000
+
+  @type page_error :: %{required(:field) => :page, required(:message) => String.t()}
+  @type page_projection :: %{
+          required(:total) => non_neg_integer(),
+          required(:limit) => pos_integer(),
+          required(:offset) => non_neg_integer()
+        }
+
+  attr :page, :map, required: true
+  attr :base_path, :string, required: true
+  attr :current_params, :map, required: true
+  attr :id_prefix, :string, required: true
+  attr :range_id, :string, required: true
+  attr :range_role, :string, required: true
+  attr :label, :string, required: true
+  attr :placement, :atom, required: true, values: [:top, :bottom]
+  attr :show_border, :boolean, default: true
+
+  def controls(assigns) do
+    assigns = assign(assigns, metadata(assigns.page))
+
+    ~H"""
+    <div
+      :if={@page.total > 0}
+      class={[
+        "border-base-300/70 py-3",
+        @show_border && @placement == :top && "border-b px-3",
+        @show_border && @placement == :bottom && "border-t px-3",
+        !@show_border && "px-3"
+      ]}
+    >
+      <nav
+        id={@id_prefix}
+        class="grid gap-3 text-sm sm:grid-cols-[auto_minmax(0,1fr)_auto] sm:items-center"
+        aria-label={pagination_label(@label, @placement)}
+      >
+        <p data-role="pagination-status" class="text-base-content/60">
+          Page {@current_page} of {@total_pages}
+        </p>
+        <p
+          id={@range_id}
+          data-role={@range_role}
+          class="text-center tabular-nums text-base-content/70"
+        >
+          {@range}
+        </p>
+        <div class="join">
+          <.pagination_link
+            id={"#{@id_prefix}-prev"}
+            label="Previous"
+            enabled={@has_previous_page}
+            path={__MODULE__.path(@base_path, @current_params, @previous_page)}
+          />
+          <.pagination_link
+            id={"#{@id_prefix}-next"}
+            label="Next"
+            enabled={@has_next_page}
+            path={__MODULE__.path(@base_path, @current_params, @next_page)}
+          />
+        </div>
+      </nav>
+    </div>
+    """
+  end
+
+  attr :id, :string, required: true
+  attr :label, :string, required: true
+  attr :enabled, :boolean, required: true
+  attr :path, :string, required: true
+
+  defp pagination_link(assigns) do
+    ~H"""
+    <.link
+      :if={@enabled}
+      id={@id}
+      data-role="pagination-link"
+      patch={@path}
+      class="btn btn-sm join-item"
+    >
+      {@label}
+    </.link>
+    <span
+      :if={!@enabled}
+      id={@id}
+      data-role="pagination-link"
+      aria-disabled="true"
+      class="btn btn-sm join-item btn-disabled"
+    >
+      {@label}
+    </span>
+    """
+  end
+
+  @spec parse_page(map()) :: {pos_integer(), page_error() | nil}
+  def parse_page(params) when is_map(params) do
+    params
+    |> Map.get("page")
+    |> normalize_page_value()
+    |> parse_page_value()
+  end
+
+  @spec offset(pos_integer(), pos_integer()) :: non_neg_integer()
+  def offset(page, page_size) when page > 0 and page_size > 0, do: (page - 1) * page_size
+
+  @spec clamp_page(pos_integer(), page_projection()) :: pos_integer()
+  def clamp_page(page, %{total: total, limit: limit})
+      when is_integer(page) and page > 0 and is_integer(total) and total >= 0 and
+             is_integer(limit) and limit > 0 do
+    min(page, total_pages(total, limit))
+  end
+
+  @spec put_page(map(), integer()) :: map()
+  def put_page(params, page) when is_map(params) and page <= 1 do
+    params
+    |> stringify_keys()
+    |> Map.delete("page")
+  end
+
+  def put_page(params, page) when is_map(params) do
+    params
+    |> stringify_keys()
+    |> Map.put("page", Integer.to_string(page))
+  end
+
+  @spec metadata(page_projection()) :: map()
+  def metadata(%{total: total, limit: limit, offset: offset})
+      when is_integer(total) and total >= 0 and is_integer(limit) and limit > 0 and
+             is_integer(offset) and offset >= 0 do
+    current_page = div(offset, limit) + 1
+
+    %{
+      current_page: current_page,
+      total_pages: total_pages(total, limit),
+      previous_page: current_page - 1,
+      next_page: current_page + 1,
+      has_previous_page: offset > 0,
+      has_next_page: offset + limit < total,
+      range: range(total, limit, offset)
+    }
+  end
+
+  @spec path(String.t(), map(), integer()) :: String.t()
+  def path(base_path, params, page) when is_binary(base_path) and is_map(params) do
+    query =
+      params
+      |> put_page(page)
+      |> Enum.reject(fn {_key, value} -> is_nil(value) or value == "" end)
+      |> Enum.sort_by(fn {key, _value} -> key end)
+      |> URI.encode_query()
+
+    if query == "", do: base_path, else: base_path <> "?" <> query
+  end
+
+  defp normalize_page_value(nil), do: nil
+  defp normalize_page_value(value) when is_binary(value), do: String.trim(value)
+  defp normalize_page_value(value) when is_integer(value), do: Integer.to_string(value)
+  defp normalize_page_value(_value), do: :invalid
+
+  defp parse_page_value(value) when value in [nil, ""], do: {1, nil}
+
+  defp parse_page_value(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {page, ""} when page > 0 and page <= @max_page -> {page, nil}
+      _other -> invalid_page()
+    end
+  end
+
+  defp parse_page_value(_value), do: invalid_page()
+
+  defp invalid_page,
+    do: {1, %{field: :page, message: "Page must be an integer between 1 and 10,000"}}
+
+  defp stringify_keys(params),
+    do: Map.new(params, fn {key, value} -> {to_string(key), value} end)
+
+  defp total_pages(total, limit), do: max(div(total + limit - 1, limit), 1)
+
+  defp range(0, _limit, _offset), do: "Showing 0 of 0"
+
+  defp range(total, limit, offset) do
+    first = offset + 1
+    last = min(offset + limit, total)
+    "Showing #{first}-#{last} of #{total}"
+  end
+
+  defp pagination_label(label, :top), do: "#{label} pagination (top)"
+  defp pagination_label(label, :bottom), do: "#{label} pagination"
+end

--- a/lib/codex_pooler_web/live/admin/pages/audit_logs_live.ex
+++ b/lib/codex_pooler_web/live/admin/pages/audit_logs_live.ex
@@ -4,6 +4,7 @@ defmodule CodexPoolerWeb.Admin.AuditLogsLive do
   alias CodexPooler.Audit
   alias CodexPooler.Pools
   alias CodexPoolerWeb.Admin.Components, as: AdminComponents
+  alias CodexPoolerWeb.Admin.LogPagination
   alias CodexPoolerWeb.Admin.PoolFilterComponents
   alias CodexPoolerWeb.DateTimeDisplay
 
@@ -22,6 +23,7 @@ defmodule CodexPoolerWeb.Admin.AuditLogsLive do
        pools: [],
        selected_pool: nil,
        audit_logs: empty_audit_logs(),
+       current_params: %{},
        selected_audit_event: nil,
        filter_form: to_form(%{}, as: :filters),
        filter_values: %{},
@@ -104,7 +106,11 @@ defmodule CodexPoolerWeb.Admin.AuditLogsLive do
               pool_filter_options={@pool_filter_options}
             />
 
-            <.audit_logs_table audit_logs={@audit_logs} datetime_preferences={@datetime_preferences} />
+            <.audit_logs_table
+              audit_logs={@audit_logs}
+              current_params={@current_params}
+              datetime_preferences={@datetime_preferences}
+            />
           </section>
         </div>
 
@@ -121,29 +127,57 @@ defmodule CodexPoolerWeb.Admin.AuditLogsLive do
     pools = Pools.list_log_filter_pools(socket.assigns.current_scope)
     {selected_pool, pool_error} = select_pool(pools, params["pool_id"])
     {filters, form_values, filter_errors} = parse_filters(params, selected_pool)
-    filter_errors = Enum.reject([pool_error | filter_errors], &is_nil/1)
+    {page, page_error} = LogPagination.parse_page(params)
+    filter_errors = Enum.reject([pool_error, page_error | filter_errors], &is_nil/1)
+    offset = LogPagination.offset(page, @page_size)
 
     audit_logs =
       if selected_pool do
-        Audit.list_events(selected_pool, limit: @page_size, filters: filters)
+        Audit.list_events(selected_pool, limit: @page_size, offset: offset, filters: filters)
       else
         Audit.list_events_for_scope(socket.assigns.current_scope,
           limit: @page_size,
+          offset: offset,
           filters: filters
         )
       end
 
-    assign(socket,
-      pools: pools,
-      selected_pool: selected_pool,
-      audit_logs: audit_logs,
-      selected_audit_event:
-        selected_audit_event(socket.assigns.selected_audit_event, audit_logs.items),
-      filter_form: to_form(form_values, as: :filters, errors: form_errors(filter_errors)),
-      filter_values: form_values,
-      filter_errors: filter_errors,
-      pool_filter_options: PoolFilterComponents.pool_filter_options(pools)
-    )
+    case LogPagination.clamp_page(page, audit_logs) do
+      ^page ->
+        assign(socket,
+          pools: pools,
+          selected_pool: selected_pool,
+          audit_logs: audit_logs,
+          current_params:
+            params
+            |> normalize_query_params()
+            |> LogPagination.put_page(page),
+          selected_audit_event:
+            selected_audit_event(socket.assigns.selected_audit_event, audit_logs.items),
+          filter_form: to_form(form_values, as: :filters, errors: form_errors(filter_errors)),
+          filter_values: form_values,
+          filter_errors: filter_errors,
+          pool_filter_options: PoolFilterComponents.pool_filter_options(pools)
+        )
+
+      clamped_page ->
+        push_patch(socket,
+          to:
+            LogPagination.path(
+              "/admin/audit-logs",
+              normalize_query_params(params),
+              clamped_page
+            )
+        )
+    end
+  end
+
+  defp normalize_query_params(params) do
+    params
+    |> Map.new(fn {key, value} -> {to_string(key), value} end)
+    |> Map.take(~w(pool_id outcome actor_type actor action target date_from date_to page))
+    |> Enum.reject(fn {_key, value} -> is_nil(value) or value == "" end)
+    |> Map.new()
   end
 
   defp parse_filters(params, selected_pool) do

--- a/lib/codex_pooler_web/live/admin/pages/request_logs_live.ex
+++ b/lib/codex_pooler_web/live/admin/pages/request_logs_live.ex
@@ -7,6 +7,7 @@ defmodule CodexPoolerWeb.Admin.RequestLogsLive do
   alias CodexPooler.Upstreams
   alias CodexPooler.Upstreams.Assignments, as: UpstreamAssignments
   alias CodexPoolerWeb.Admin.Components, as: AdminComponents
+  alias CodexPoolerWeb.Admin.LogPagination
   alias CodexPoolerWeb.Admin.PoolEventSubscriptions
   alias CodexPoolerWeb.Admin.PoolFilterComponents
   alias CodexPoolerWeb.Admin.RequestLogDetailDrawer
@@ -34,6 +35,7 @@ defmodule CodexPoolerWeb.Admin.RequestLogsLive do
        selected_pool: nil,
        request_logs: empty_request_logs(),
        current_params: %{},
+       current_page: 1,
        filter_form: to_form(%{}, as: :filters),
        filter_values: %{},
        filter_errors: [],
@@ -238,6 +240,7 @@ defmodule CodexPoolerWeb.Admin.RequestLogsLive do
 
             <.request_logs_table
               request_logs={@request_logs}
+              current_params={@current_params}
               datetime_preferences={@datetime_preferences}
             />
           </section>
@@ -317,36 +320,54 @@ defmodule CodexPoolerWeb.Admin.RequestLogsLive do
     {filters, form_values, filter_errors} =
       RequestLogFilterForm.parse_filters(params, selected_pool, visible_upstream_identity_ids)
 
-    filter_errors = Enum.reject([pool_error | filter_errors], &is_nil/1)
+    {page, page_error} = LogPagination.parse_page(params)
+    filter_errors = Enum.reject([pool_error, page_error | filter_errors], &is_nil/1)
     visible_pool_ids = pool_ids(pools)
-    request_logs = request_logs(selected_pool, filters, visible_pool_ids)
+    request_logs = request_logs(selected_pool, filters, visible_pool_ids, page)
     model_filter_models = request_log_models(selected_pool, visible_pool_ids)
 
-    socket
-    |> cancel_request_logs_reload_timer()
-    |> maybe_subscribe_pool_events(pools, selected_pool)
-    |> assign(
-      pools: pools,
-      selected_pool: selected_pool,
-      request_logs: request_logs,
-      current_params: params,
-      filter_form:
-        to_form(form_values,
-          as: :filters,
-          errors: RequestLogFilterForm.form_errors(filter_errors)
-        ),
-      filter_values: form_values,
-      filter_errors: filter_errors,
-      pool_filter_options: PoolFilterComponents.pool_filter_options(pools),
-      model_filter_options: model_filter_options(model_filter_models, form_values["model"]),
-      upstream_account_options: upstream_account_options(upstream_filter_identities),
-      visible_pool_ids: visible_pool_ids,
-      request_log_filters: filters,
-      request_logs_loaded?: true
-    )
-    |> assign_selected_request_log(params)
-    |> maybe_clear_missing_selected_request_log()
-    |> notify_request_logs_reload(reload_stage, started_at)
+    case LogPagination.clamp_page(page, request_logs) do
+      ^page ->
+        socket
+        |> cancel_request_logs_reload_timer()
+        |> maybe_subscribe_pool_events(pools, selected_pool)
+        |> assign(
+          pools: pools,
+          selected_pool: selected_pool,
+          request_logs: request_logs,
+          current_params:
+            params
+            |> normalize_request_log_query_params()
+            |> LogPagination.put_page(page),
+          current_page: page,
+          filter_form:
+            to_form(form_values,
+              as: :filters,
+              errors: RequestLogFilterForm.form_errors(filter_errors)
+            ),
+          filter_values: form_values,
+          filter_errors: filter_errors,
+          pool_filter_options: PoolFilterComponents.pool_filter_options(pools),
+          model_filter_options: model_filter_options(model_filter_models, form_values["model"]),
+          upstream_account_options: upstream_account_options(upstream_filter_identities),
+          visible_pool_ids: visible_pool_ids,
+          request_log_filters: filters,
+          request_logs_loaded?: true
+        )
+        |> assign_selected_request_log(params)
+        |> maybe_clear_missing_selected_request_log()
+        |> notify_request_logs_reload(reload_stage, started_at)
+
+      clamped_page ->
+        push_patch(socket,
+          to:
+            LogPagination.path(
+              "/admin/request-logs",
+              normalize_request_log_query_params(params),
+              clamped_page
+            )
+        )
+    end
   end
 
   defp refresh_request_logs_from_events(socket) do
@@ -354,19 +375,33 @@ defmodule CodexPoolerWeb.Admin.RequestLogsLive do
     selected_pool = socket.assigns.selected_pool
     filters = socket.assigns.request_log_filters
     visible_pool_ids = socket.assigns.visible_pool_ids
-    request_logs = request_logs(selected_pool, filters, visible_pool_ids)
+    page = socket.assigns.current_page
+    request_logs = request_logs(selected_pool, filters, visible_pool_ids, page)
     model_filter_models = request_log_models(selected_pool, visible_pool_ids)
 
-    socket
-    |> cancel_request_logs_reload_timer()
-    |> assign(
-      request_logs: request_logs,
-      model_filter_options:
-        model_filter_options(model_filter_models, socket.assigns.filter_values["model"])
-    )
-    |> assign_selected_request_log(socket.assigns.current_params)
-    |> maybe_clear_missing_selected_request_log()
-    |> notify_request_logs_reload(:event_refresh, started_at)
+    case LogPagination.clamp_page(page, request_logs) do
+      ^page ->
+        socket
+        |> cancel_request_logs_reload_timer()
+        |> assign(
+          request_logs: request_logs,
+          model_filter_options:
+            model_filter_options(model_filter_models, socket.assigns.filter_values["model"])
+        )
+        |> assign_selected_request_log(socket.assigns.current_params)
+        |> maybe_clear_missing_selected_request_log()
+        |> notify_request_logs_reload(:event_refresh, started_at)
+
+      clamped_page ->
+        push_patch(socket,
+          to:
+            LogPagination.path(
+              "/admin/request-logs",
+              socket.assigns.current_params,
+              clamped_page
+            )
+        )
+    end
   end
 
   defp assign_selected_request_log(socket, params) do
@@ -426,13 +461,19 @@ defmodule CodexPoolerWeb.Admin.RequestLogsLive do
     |> Map.new()
   end
 
-  defp request_logs(selected_pool, filters, _visible_pool_ids) when not is_nil(selected_pool) do
-    Accounting.list_request_logs(selected_pool, limit: @page_size, filters: filters)
+  defp request_logs(selected_pool, filters, _visible_pool_ids, page)
+       when not is_nil(selected_pool) do
+    Accounting.list_request_logs(selected_pool,
+      limit: @page_size,
+      offset: LogPagination.offset(page, @page_size),
+      filters: filters
+    )
   end
 
-  defp request_logs(_selected_pool, filters, visible_pool_ids) do
+  defp request_logs(_selected_pool, filters, visible_pool_ids, page) do
     Accounting.list_request_logs(nil,
       limit: @page_size,
+      offset: LogPagination.offset(page, @page_size),
       filters: filters,
       visible_pool_ids: visible_pool_ids
     )

--- a/test/codex_pooler_web/live/admin/log_pagination_test.exs
+++ b/test/codex_pooler_web/live/admin/log_pagination_test.exs
@@ -1,0 +1,56 @@
+defmodule CodexPoolerWeb.Admin.LogPaginationTest do
+  use ExUnit.Case, async: true
+
+  alias CodexPoolerWeb.Admin.LogPagination
+
+  describe "parse_page/1" do
+    test "defaults missing and blank pages to the first page" do
+      assert {1, nil} = LogPagination.parse_page(%{})
+      assert {1, nil} = LogPagination.parse_page(%{"page" => "  "})
+    end
+
+    test "accepts trimmed positive integers" do
+      assert {3, nil} = LogPagination.parse_page(%{"page" => " 3 "})
+      assert {4, nil} = LogPagination.parse_page(%{"page" => 4})
+    end
+
+    test "rejects non-positive, partial, and structured values without raising" do
+      for value <- ["0", "-1", "2x", "10001", %{"nested" => "1"}] do
+        assert {1, %{field: :page, message: "Page must be an integer between 1 and 10,000"}} =
+                 LogPagination.parse_page(%{"page" => value})
+      end
+    end
+  end
+
+  test "computes offsets, bounds, navigation state, and visible ranges" do
+    assert LogPagination.offset(3, 50) == 100
+    assert LogPagination.clamp_page(99, %{total: 51, limit: 50, offset: 4_900}) == 2
+    assert LogPagination.clamp_page(7, %{total: 0, limit: 50, offset: 300}) == 1
+
+    assert %{
+             current_page: 2,
+             total_pages: 2,
+             previous_page: 1,
+             next_page: 3,
+             has_previous_page: true,
+             has_next_page: false,
+             range: "Showing 51-51 of 51"
+           } = LogPagination.metadata(%{total: 51, limit: 50, offset: 50})
+
+    assert %{current_page: 1, total_pages: 1, range: "Showing 0 of 0"} =
+             LogPagination.metadata(%{total: 0, limit: 50, offset: 0})
+  end
+
+  test "builds deterministic paths while removing first-page and blank parameters" do
+    params = %{"model" => "gpt-5", "page" => "8", "status" => "", pool_id: "pool-1"}
+
+    assert LogPagination.path("/admin/request-logs", params, 2) ==
+             "/admin/request-logs?model=gpt-5&page=2&pool_id=pool-1"
+
+    assert LogPagination.path("/admin/request-logs", params, 1) ==
+             "/admin/request-logs?model=gpt-5&pool_id=pool-1"
+
+    assert LogPagination.path("/admin/audit-logs", %{"page" => "3"}, 1) ==
+             "/admin/audit-logs"
+  end
+end

--- a/test/codex_pooler_web/live/admin/pages/audit_logs_live_test.exs
+++ b/test/codex_pooler_web/live/admin/pages/audit_logs_live_test.exs
@@ -703,6 +703,60 @@ defmodule CodexPoolerWeb.Admin.AuditLogsLiveTest do
     assert has_element?(owner_view, "#audit-log-row-#{nilified_event.id}", "Pool deleted")
   end
 
+  test "paginates audit logs, preserves filters, and clamps overflow pages", %{conn: conn} do
+    now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+
+    for index <- 1..52 do
+      %AuditEvent{
+        occurred_at: DateTime.add(now, -index, :second),
+        actor_type: "system",
+        action: "pool.update",
+        target_type: "pool",
+        target_id: Ecto.UUID.generate(),
+        outcome: "success",
+        details: %{"index" => index}
+      }
+      |> Repo.insert!()
+    end
+
+    {:ok, view, _html} = live(conn, ~p"/admin/audit-logs?action=pool.update")
+
+    assert has_element?(view, "#admin-audit-logs-pagination-top", "Page 1 of 2")
+    assert has_element?(view, "#admin-audit-logs-pagination-bottom", "Page 1 of 2")
+    assert has_element?(view, "#admin-audit-logs-range-top", "Showing 1-50 of 52")
+    assert has_element?(view, "#admin-audit-logs-range-bottom", "Showing 1-50 of 52")
+    assert has_element?(view, "#admin-audit-logs-pagination-top-prev.btn-disabled")
+    refute has_element?(view, "#admin-audit-logs-pagination-top-next.btn-disabled")
+
+    view
+    |> element("#admin-audit-logs-pagination-top-next")
+    |> render_click()
+
+    assert_patch(view, "/admin/audit-logs?action=pool.update&page=2")
+    assert has_element?(view, "#admin-audit-logs-pagination-bottom", "Page 2 of 2")
+    assert has_element?(view, "#admin-audit-logs-range-bottom", "Showing 51-52 of 52")
+    refute has_element?(view, "#admin-audit-logs-pagination-bottom-prev.btn-disabled")
+    assert has_element?(view, "#admin-audit-logs-pagination-bottom-next.btn-disabled")
+
+    view
+    |> element("#admin-audit-logs-pagination-bottom-prev")
+    |> render_click()
+
+    assert_patch(view, "/admin/audit-logs?action=pool.update")
+
+    assert {:error, {:live_redirect, %{to: overflow_to}}} =
+             live(conn, ~p"/admin/audit-logs?action=pool.update&page=99")
+
+    assert overflow_to == "/admin/audit-logs?action=pool.update&page=2"
+  end
+
+  test "clamps an empty audit-log page to page one", %{conn: conn} do
+    assert {:error, {:live_redirect, %{to: overflow_to}}} =
+             live(conn, ~p"/admin/audit-logs?action=auth.logout&page=4")
+
+    assert overflow_to == "/admin/audit-logs?action=auth.logout"
+  end
+
   defp set_datetime_preferences!(user, attrs) do
     {1, _rows} =
       from(operator in User, where: operator.id == ^user.id)

--- a/test/codex_pooler_web/live/admin/pages/request_logs_live_test.exs
+++ b/test/codex_pooler_web/live/admin/pages/request_logs_live_test.exs
@@ -308,6 +308,14 @@ defmodule CodexPoolerWeb.Admin.RequestLogsLiveTest do
     assert has_element?(view, "#request-logs-table")
     assert has_element?(view, "#mobile-request-logs-table")
     assert has_element?(view, "#mobile-request-logs-table-body")
+    assert has_element?(view, "#admin-request-logs-pagination-top", "Page 1 of 1")
+    assert has_element?(view, "#admin-request-logs-pagination", "Page 1 of 1")
+    assert has_element?(view, "#admin-request-logs-range-top", "Showing")
+    assert has_element?(view, "#admin-request-logs-range", "Showing")
+    assert has_element?(view, "#admin-request-logs-pagination-top-prev.btn-disabled")
+    assert has_element?(view, "#admin-request-logs-pagination-prev.btn-disabled")
+    assert has_element?(view, "#admin-request-logs-pagination-top-next.btn-disabled")
+    assert has_element?(view, "#admin-request-logs-pagination-next.btn-disabled")
     assert has_element?(view, "#admin-request-logs", "Usage")
     assert has_element?(view, "#admin-request-logs", "$0.12")
     assert has_element?(view, "#request-log-row-#{request.id}", "Admin key")
@@ -2092,6 +2100,84 @@ defmodule CodexPoolerWeb.Admin.RequestLogsLiveTest do
            )
   end
 
+  test "paginates request logs, preserves filters, and clamps overflow pages",
+       %{conn: conn, scope: scope} do
+    {:ok, pool} = Pools.create_pool(scope, %{slug: "paginate-logs", name: "Paginate Logs"})
+    reload_ref = attach_request_log_reload_telemetry()
+    now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+
+    logs =
+      for index <- 1..51 do
+        request_log_fixture(pool, %{
+          correlation_id: "req-paginate-#{index}",
+          requested_model: "gpt-paginate",
+          admitted_at: DateTime.add(now, -index, :second)
+        }).request
+      end
+
+    newest = List.first(logs)
+    oldest = List.last(logs)
+
+    {:ok, view, _html} =
+      live(conn, ~p"/admin/request-logs?pool_id=#{pool.id}&model=gpt-paginate")
+
+    assert_request_log_reload(reload_ref, :initial_load, :selected_pool)
+    assert has_element?(view, "#admin-request-logs-pagination-top", "Page 1 of 2")
+    assert has_element?(view, "#admin-request-logs-pagination", "Page 1 of 2")
+    assert has_element?(view, "#admin-request-logs-range-top", "Showing 1-50 of 51")
+    assert has_element?(view, "#admin-request-logs-range", "Showing 1-50 of 51")
+    assert has_element?(view, "#request-log-row-#{newest.id}")
+    refute has_element?(view, "#request-log-row-#{oldest.id}")
+    assert has_element?(view, "#admin-request-logs-pagination-top-prev.btn-disabled")
+    refute has_element?(view, "#admin-request-logs-pagination-top-next.btn-disabled")
+
+    view
+    |> element("#admin-request-logs-pagination-top-next")
+    |> render_click()
+
+    assert_patch(view, ~p"/admin/request-logs?model=gpt-paginate&page=2&pool_id=#{pool.id}")
+    assert_request_log_reload(reload_ref, :filter_patch, :selected_pool)
+    assert has_element?(view, "#admin-request-logs-pagination", "Page 2 of 2")
+    assert has_element?(view, "#admin-request-logs-range", "Showing 51-51 of 51")
+    assert has_element?(view, "#request-log-row-#{oldest.id}")
+    refute has_element?(view, "#request-log-row-#{newest.id}")
+    refute has_element?(view, "#admin-request-logs-pagination-prev.btn-disabled")
+    assert has_element?(view, "#admin-request-logs-pagination-next.btn-disabled")
+
+    refreshed_request =
+      request_log_fixture(pool, %{
+        correlation_id: "req-paginate-refresh",
+        requested_model: "gpt-paginate",
+        admitted_at: DateTime.add(now, 1, :second)
+      }).request
+
+    assert {:ok, _event} =
+             Events.broadcast_request_logs(pool.id, "request_log_created", %{
+               request_id: refreshed_request.id,
+               status: refreshed_request.status
+             })
+
+    assert_request_log_reload(reload_ref, :event_refresh, :selected_pool)
+    assert has_element?(view, "#admin-request-logs-pagination", "Page 2 of 2")
+    assert has_element?(view, "#admin-request-logs-range", "Showing 51-52 of 52")
+    refute has_element?(view, "#request-log-row-#{refreshed_request.id}")
+
+    assert {:error, {:live_redirect, %{to: overflow_to}}} =
+             live(conn, ~p"/admin/request-logs?pool_id=#{pool.id}&model=gpt-paginate&page=99")
+
+    assert overflow_to ==
+             ~p"/admin/request-logs?model=gpt-paginate&page=2&pool_id=#{pool.id}"
+  end
+
+  test "clamps an empty request-log page to page one", %{conn: conn, scope: scope} do
+    {:ok, pool} = Pools.create_pool(scope, %{slug: "empty-page-logs", name: "Empty Page Logs"})
+
+    assert {:error, {:live_redirect, %{to: overflow_to}}} =
+             live(conn, ~p"/admin/request-logs?pool_id=#{pool.id}&status=failed&page=7")
+
+    assert overflow_to == ~p"/admin/request-logs?pool_id=#{pool.id}&status=failed"
+  end
+
   test "missing request timestamp keeps not recorded display", %{scope: scope} do
     {:ok, pool} =
       Pools.create_pool(scope, %{slug: "missing-time-logs", name: "Missing Time Logs"})
@@ -2108,6 +2194,7 @@ defmodule CodexPoolerWeb.Admin.RequestLogsLiveTest do
     html =
       render_component(&RequestLogsPresentation.request_logs_table/1,
         request_logs: request_logs,
+        current_params: %{},
         datetime_preferences: %{datetime_format: "default", timezone: "Etc/UTC"}
       )
 


### PR DESCRIPTION
## Summary

Implements item 11 by adding URL-driven pagination to both admin log views using one shared pagination component and helper:

- `/admin/audit-logs`
- `/admin/request-logs`

Both pages now render matching top and bottom controls, preserve active filters while navigating, omit `page=1` from canonical URLs, show exact visible ranges, and clamp stale or overflowing page numbers.

This PR is based directly on current `main` (`b628d7ea`). The GitHub audit found no existing audit/request-log pagination PR or issue; the Jobs explorer is the closest existing UI precedent.

## Context

The underlying readers already expose a stable offset-pagination contract:

- `items`
- exact filtered `total`
- `limit`
- `offset`

Audit events are ordered newest-first by their existing stable ordering, and request logs are ordered by `admitted_at DESC, id DESC`. The two LiveViews nevertheless always requested `limit: 50` with the default offset, so records after the first 50 were inaccessible from the admin UI.

No accounting or audit query semantics needed to change. This PR wires the existing offset support into URL state and presentation.

## Shared pagination design

`CodexPoolerWeb.Admin.LogPagination` owns the behavior shared by both pages:

- parses and validates the `page` query parameter;
- bounds pages to `1..10,000` before an SQL `OFFSET` can be constructed;
- computes page offsets from the existing page size;
- computes page count, previous/next state, and visible record range;
- clamps requested pages to the last available page, including an empty result set;
- builds deterministic, filter-preserving URLs;
- removes `page` when navigating back to page 1;
- renders the common accessible Previous/Next controls, page status, and range.

The audit and request-log components only supply route-specific IDs, labels, range roles, and border placement. This avoids maintaining two copies of the same pagination markup and arithmetic.

## URL and state behavior

| Situation | Behavior |
| --- | --- |
| No `page` or blank `page` | Load page 1 |
| Valid page `N` | Query with offset `(N - 1) * 50` |
| Invalid, structured, non-positive, or over-limit page | Fall back to page 1 and expose validation feedback |
| Requested page exceeds the filtered result count | Patch to the last available page while preserving filters |
| Requested page is greater than 1 and the result set is empty | Patch to the canonical page-1 URL |
| Previous navigation reaches page 1 | Remove the `page` query parameter |
| A request-log event refresh arrives while viewing page `N` | Refresh page `N`; clamp only if the result count shrank below it |
| A filter changes | Existing filter handlers produce a fresh filter URL and naturally reset to page 1 |

Request-log drawer state remains in `current_params`, so opening or closing a selected request continues to preserve the current page and filters.

## Presentation

Both pages render pagination above and below their desktop/mobile log tables:

- `Page N of M`
- `Showing X-Y of Z`
- disabled Previous/Next controls at the boundaries
- filter-preserving LiveView patches
- distinct accessible labels for top and bottom controls

Controls render whenever the filtered result has records, including a last page that becomes temporarily empty before LiveView applies its canonical clamp.

## Realtime request-log refresh

Request logs can refresh from PostgreSQL-backed events. The LiveView now stores the current page separately from parsed filters and uses that page for lightweight event refreshes. If a new row arrives, the operator remains on the current page. If rows disappear and the page is no longer valid, the view patches to the new last page.

This keeps realtime behavior consistent with explicit pagination instead of unexpectedly returning operators to page 1.

## Safety and access control

- Pool and scope visibility still come from the existing `Pools.list_log_filter_pools/1`, audit readers, and request-log readers.
- Selected-pool and all-visible-pools behavior is unchanged.
- Pagination links preserve only the parameters already held by each LiveView.
- Page input is bounded before calculating database offsets.
- No raw log content, credentials, or sensitive metadata is added to URLs or pagination output.
- Existing redaction and drawer access checks are unchanged.

## Tests

The regression coverage verifies:

- shared parsing for missing, blank, valid, malformed, structured, non-positive, and over-limit pages;
- shared offset, clamp, metadata, navigation, range, and deterministic-path behavior;
- audit-log page 1/page 2 navigation with filters preserved;
- request-log page 1/page 2 navigation with filters preserved;
- canonical removal of `page=1`;
- exact `Showing X-Y of Z` ranges;
- disabled controls at first/last-page boundaries;
- overflow clamping to the last page;
- empty-result clamping to page 1;
- request-log event refresh while the operator remains on page 2;
- existing audit/request rendering, filtering, authorization, redaction, drawer, and realtime tests.

Local verification:

- `mix compile --warnings-as-errors` - passed in a clean build volume
- complete shared-pagination, audit-log LiveView, and request-log LiveView suites - **48 passed**
- focused page-2 realtime refresh regression - **1 passed**
- `mix credo --strict` for all eight changed files - no issues
- `mix format --check-formatted` for the new shared module and changed test files - passed
- `git diff --check` - passed

## Files changed

- shared pagination component/helper
- audit-log table component
- request-log presentation component
- audit-log LiveView
- request-log LiveView
- shared pagination unit tests
- audit-log LiveView pagination tests
- request-log LiveView pagination/realtime tests

## Scope boundaries

This PR intentionally does **not** include:

- the saved-reset quota fix from #153;
- unrelated local admin UI changes;
- a refactor of the existing Jobs explorer pagination;
- changes to audit/accounting persistence or query contracts;
- schema migrations or data backfills;
- deployment or Portainer changes.

## Risk and rollback

The pages use the repositories' existing offset pagination, so new records can shift later pages while an operator is browsing. That is the established reader contract and is preferable here to broadening this UI change into a cursor-pagination data-layer rewrite. Stable secondary ordering prevents nondeterministic ties within a snapshot.

Rollback is a single commit revert. There are no schema changes, backfills, or irreversible writes.