### PR TITLE
fix(accounting): prevent terminal request lifecycle races

### DIFF
--- a/lib/codex_pooler/accounting.ex
+++ b/lib/codex_pooler/accounting.ex
@@ -57,11 +57,11 @@ defmodule CodexPooler.Accounting do
   defdelegate latest_success_by_assignment_ids(assignment_ids), to: LedgerReads
 
   @spec create_attempt(Request.t(), PoolUpstreamAssignment.t(), map()) ::
-          {:ok, Attempt.t()} | {:error, Ecto.Changeset.t()}
+          {:ok, Attempt.t()} | {:error, Ecto.Changeset.t() | accounting_error()}
   defdelegate create_attempt(request, assignment, attrs \\ %{}), to: RequestLifecycle
 
   @spec record_retryable_attempt_failure(Attempt.t(), map()) ::
-          {:ok, Attempt.t()} | {:error, Ecto.Changeset.t()}
+          {:ok, Attempt.t()} | {:error, Ecto.Changeset.t() | accounting_error()}
   defdelegate record_retryable_attempt_failure(attempt, attrs \\ %{}), to: RequestLifecycle
 
   @spec finalize_reserved_request_failure(Request.t(), map()) :: request_result()

--- a/lib/codex_pooler/accounting/lifecycle/request_lifecycle.ex
+++ b/lib/codex_pooler/accounting/lifecycle/request_lifecycle.ex
@@ -34,6 +34,8 @@ defmodule CodexPooler.Accounting.RequestLifecycle do
   @usage_known "usage_known"
   @usage_unknown "usage_unknown"
   @usage_not_applicable "not_applicable"
+  @dispatchable_request_statuses ~w(accepted in_progress)
+  @retryable_attempt_statuses ~w(queued in_progress)
   @type auth :: CodexPooler.Access.auth_context()
   @type model_ref :: Model.t() | Ecto.UUID.t() | String.t() | nil
   @type accounting_error :: Metadata.accounting_error()
@@ -87,13 +89,17 @@ defmodule CodexPooler.Accounting.RequestLifecycle do
   end
 
   @spec create_attempt(Request.t(), PoolUpstreamAssignment.t(), map()) ::
-          {:ok, Attempt.t()} | {:error, Ecto.Changeset.t()}
+          {:ok, Attempt.t()} | {:error, Ecto.Changeset.t() | accounting_error()}
   def create_attempt(%Request{} = request, %PoolUpstreamAssignment{} = assignment, attrs \\ %{}) do
-    model = attempt_model(request, attrs)
-    pricing_snapshot = attempt_pricing_snapshot(request, model, attrs)
     timestamp = now(attrs)
 
     Repo.transaction(fn ->
+      request = Repo.get!(Request, request.id, lock: "FOR UPDATE")
+      ensure_request_dispatchable!(request)
+
+      model = attempt_model(request, attrs)
+      pricing_snapshot = attempt_pricing_snapshot(request, model, attrs)
+
       attempt_number =
         Repo.aggregate(from(a in Attempt, where: a.request_id == ^request.id), :count, :id) + 1
 
@@ -133,11 +139,17 @@ defmodule CodexPooler.Accounting.RequestLifecycle do
   end
 
   @spec record_retryable_attempt_failure(Attempt.t(), map()) ::
-          {:ok, Attempt.t()} | {:error, Ecto.Changeset.t()}
+          {:ok, Attempt.t()} | {:error, Ecto.Changeset.t() | accounting_error()}
   def record_retryable_attempt_failure(%Attempt{} = attempt, attrs \\ %{}) do
     timestamp = now(attrs)
 
     Repo.transaction(fn ->
+      request = Repo.get!(Request, attempt.request_id, lock: "FOR UPDATE")
+      ensure_request_dispatchable!(request)
+
+      attempt = Repo.get!(Attempt, attempt.id, lock: "FOR UPDATE")
+      ensure_attempt_retryable!(attempt)
+
       case attempt
            |> Ecto.Changeset.change(%{
              status: Map.get(attrs, :attempt_status, "retryable_failed"),
@@ -160,6 +172,32 @@ defmodule CodexPooler.Accounting.RequestLifecycle do
       end
     end)
     |> unwrap_transaction()
+  end
+
+  defp ensure_request_dispatchable!(%Request{status: status, completed_at: nil})
+       when status in @dispatchable_request_statuses,
+       do: :ok
+
+  defp ensure_request_dispatchable!(%Request{}) do
+    Repo.rollback(
+      Metadata.accounting_error(
+        :request_already_finalized,
+        "request lifecycle completed before another upstream attempt could start"
+      )
+    )
+  end
+
+  defp ensure_attempt_retryable!(%Attempt{status: status, completed_at: nil})
+       when status in @retryable_attempt_statuses,
+       do: :ok
+
+  defp ensure_attempt_retryable!(%Attempt{}) do
+    Repo.rollback(
+      Metadata.accounting_error(
+        :attempt_already_finalized,
+        "upstream attempt completed before retryable failure could be recorded"
+      )
+    )
   end
 
   @spec finalize_reserved_request_failure(Request.t(), map()) :: request_result()

--- a/lib/codex_pooler/accounting/lifecycle/request_lifecycle/recovery.ex
+++ b/lib/codex_pooler/accounting/lifecycle/request_lifecycle/recovery.ex
@@ -3,7 +3,7 @@ defmodule CodexPooler.Accounting.RequestLifecycle.Recovery do
 
   import Ecto.Query
 
-  alias CodexPooler.Accounting.{Attempt, LedgerEntry, Request}
+  alias CodexPooler.Accounting.{Attempt, LedgerEntry, Request, RequestLogFacts}
   alias CodexPooler.Accounting.RequestLifecycle
   alias CodexPooler.Gateway.Persistence.RuntimeCleanup
   alias CodexPooler.Repo
@@ -11,14 +11,18 @@ defmodule CodexPooler.Accounting.RequestLifecycle.Recovery do
   @stale_after_seconds 6 * 60 * 60
   @request_statuses ~w(accepted in_progress)
   @attempt_statuses ~w(queued in_progress retryable_failed failed cancelled)
+  @terminal_request_statuses ~w(succeeded failed rejected cancelled)
+  @open_attempt_statuses ~w(queued in_progress)
   @recovery_code "stale_reservation_recovered"
+  @terminal_attempt_recovery_code "terminal_request_attempt_recovered"
   @recovery_source "stale_reservation_recovery"
 
   @spec recover_stale_reservations(DateTime.t(), keyword()) ::
           {:ok,
            %{
              required(:stale_reservations_released) => non_neg_integer(),
-             required(:stale_reservations_settled) => non_neg_integer()
+             required(:stale_reservations_settled) => non_neg_integer(),
+             required(:stale_terminal_attempts_recovered) => non_neg_integer()
            }}
           | {:error, term()}
   def recover_stale_reservations(now, opts \\ []) do
@@ -27,9 +31,14 @@ defmodule CodexPooler.Accounting.RequestLifecycle.Recovery do
 
     limit = Keyword.get(opts, :limit, 100)
 
-    now
-    |> stale_requests(cutoff, limit)
-    |> Enum.reduce_while({:ok, initial_summary()}, &recover_request(&1, &2, now))
+    with {:ok, summary} <-
+           now
+           |> stale_requests(cutoff, limit)
+           |> Enum.reduce_while({:ok, initial_summary()}, &recover_request(&1, &2, now)) do
+      cutoff
+      |> stale_terminal_attempts(limit)
+      |> Enum.reduce_while({:ok, summary}, &recover_terminal_attempt(&1, &2, now))
+    end
   end
 
   defp stale_requests(now, cutoff, limit) do
@@ -76,6 +85,68 @@ defmodule CodexPooler.Accounting.RequestLifecycle.Recovery do
     )
   end
 
+  defp stale_terminal_attempts(cutoff, limit) do
+    Repo.all(
+      from attempt in Attempt,
+        join: request in Request,
+        on: request.id == attempt.request_id,
+        where:
+          request.status in ^@terminal_request_statuses and
+            attempt.status in ^@open_attempt_statuses and attempt.started_at <= ^cutoff,
+        order_by: [asc: attempt.started_at, asc: attempt.id],
+        limit: ^limit,
+        select: {request.id, attempt.id}
+    )
+  end
+
+  defp recover_terminal_attempt({request_id, attempt_id}, {:ok, summary}, now) do
+    case recover_terminal_attempt(request_id, attempt_id, now) do
+      {:ok, :recovered} ->
+        {:cont, {:ok, increment(summary, :stale_terminal_attempts_recovered)}}
+
+      {:ok, :noop} ->
+        {:cont, {:ok, summary}}
+
+      {:error, reason} ->
+        {:halt, {:error, reason}}
+    end
+  end
+
+  defp recover_terminal_attempt(request_id, attempt_id, now) do
+    Repo.transaction(fn ->
+      request = Repo.get(Request, request_id, lock: "FOR UPDATE")
+      attempt = Repo.get(Attempt, attempt_id, lock: "FOR UPDATE")
+
+      if terminal_request_with_open_attempt?(request, attempt) do
+        attempt =
+          attempt
+          |> Ecto.Changeset.change(%{
+            status: "failed",
+            completed_at: now,
+            retryable: false,
+            network_error_code: @terminal_attempt_recovery_code,
+            error_message: "open attempt recovered after request lifecycle had already completed",
+            usage_status: "usage_unknown"
+          })
+          |> Repo.update!()
+
+        RequestLogFacts.record_attempt_written!(attempt)
+        :recovered
+      else
+        :noop
+      end
+    end)
+  end
+
+  defp terminal_request_with_open_attempt?(
+         %Request{status: request_status},
+         %Attempt{status: attempt_status}
+       ) do
+    request_status in @terminal_request_statuses and attempt_status in @open_attempt_statuses
+  end
+
+  defp terminal_request_with_open_attempt?(_request, _attempt), do: false
+
   defp release_undispatched_request(%Request{} = request, now) do
     with {:ok, result} <-
            RequestLifecycle.finalize_reserved_request_failure(request, %{
@@ -119,7 +190,11 @@ defmodule CodexPooler.Accounting.RequestLifecycle.Recovery do
   defp attempt_id(_attempt), do: nil
 
   defp initial_summary do
-    %{stale_reservations_released: 0, stale_reservations_settled: 0}
+    %{
+      stale_reservations_released: 0,
+      stale_reservations_settled: 0,
+      stale_terminal_attempts_recovered: 0
+    }
   end
 
   defp increment(summary, key), do: Map.update!(summary, key, &(&1 + 1))

--- a/lib/codex_pooler/gateway/runtime/dispatch/dispatch.ex
+++ b/lib/codex_pooler/gateway/runtime/dispatch/dispatch.ex
@@ -8,7 +8,7 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch do
   alias CodexPooler.Gateway.Contracts, as: GatewayContracts
   alias CodexPooler.Gateway.Payloads.RequestOptions
   alias CodexPooler.Gateway.Persistence.RoutingCircuitState
-  alias CodexPooler.Gateway.Routing.{ModelMetadata, RoutingSelection}
+  alias CodexPooler.Gateway.Routing.{ModelMetadata, RouteLifecycle, RoutingSelection}
   alias CodexPooler.Gateway.Runtime.Dispatch.Context
   alias CodexPooler.Gateway.Runtime.Dispatch.SelectedCandidateContext
   alias CodexPooler.Gateway.Runtime.Finalization.AttemptSettlement
@@ -103,7 +103,7 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch do
     with {:ok, context} <- apply_route_selection(context, selection, allow_retry?),
          {:ok, context} <- persist_route_metadata(context),
          {:ok, context} <- begin_candidate_circuit(context, selection),
-         {:ok, context} <- start_dispatch_attempt(context) do
+         {:ok, context} <- start_dispatch_attempt(context, selection) do
       transport_dispatch.(context)
     end
   end
@@ -210,7 +210,10 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch do
 
   defp route_metadata_reload?(%SelectedCandidateContext{index: index}), do: index != 0
 
-  defp start_dispatch_attempt(%SelectedCandidateContext{} = context) do
+  defp start_dispatch_attempt(
+         %SelectedCandidateContext{} = context,
+         %RoutingSelection{} = selection
+       ) do
     case Accounting.create_attempt(context.reserved.request, context.assignment, %{
            model: context.model,
            pricing_snapshot: Map.get(context.reserved, :pricing_snapshot),
@@ -223,6 +226,23 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch do
          }) do
       {:ok, attempt} ->
         {:ok, %{context | attempt: attempt, started: System.monotonic_time(:millisecond)}}
+
+      {:error, %{code: :request_already_finalized}} ->
+        selection = %{selection | circuit_state: context.routing_circuit_state}
+
+        RouteLifecycle.log_optional_result(
+          "release_finalized_request_circuit_probe",
+          [request_id: context.reserved.request.id],
+          RouteLifecycle.selection_neutral_completion(context.auth, context.model, selection)
+        )
+
+        {:error,
+         error(
+           499,
+           "request_already_finalized",
+           "request lifecycle completed before upstream dispatch",
+           "request"
+         )}
 
       {:error, reason} ->
         FailureResponse.accounting_failure(

--- a/lib/codex_pooler/gateway/runtime/finalization/attempt_settlement.ex
+++ b/lib/codex_pooler/gateway/runtime/finalization/attempt_settlement.ex
@@ -72,6 +72,21 @@ defmodule CodexPooler.Gateway.Runtime.Finalization.AttemptSettlement do
 
   defp accounting_result({:ok, value}, _operation, _request, _attempt), do: {:ok, value}
 
+  defp accounting_result(
+         {:error, %{code: code}},
+         _operation,
+         _request,
+         _attempt
+       )
+       when code in [:request_already_finalized, :attempt_already_finalized] do
+    {:error,
+     %{
+       status: 499,
+       code: Atom.to_string(code),
+       message: "request lifecycle already completed"
+     }}
+  end
+
   defp accounting_result({:error, reason}, operation, request, attempt) do
     FailureResponse.accounting_failure(operation, request, attempt, reason)
   end

--- a/test/codex_pooler/accounting_test.exs
+++ b/test/codex_pooler/accounting_test.exs
@@ -333,6 +333,47 @@ defmodule CodexPooler.AccountingTest do
       assert rollup.total_tokens == 10
     end
 
+    test "terminal request fences late retry updates and new upstream attempts" do
+      setup = accounting_setup()
+
+      assert {:ok, reserved} =
+               Accounting.reserve(
+                 setup.auth,
+                 setup.model,
+                 %{"model" => setup.model.exposed_model_id, "max_output_tokens" => 10},
+                 %{correlation_id: "corr-terminal-attempt-fence"}
+               )
+
+      assert {:ok, attempt} = Accounting.create_attempt(reserved.request, setup.assignment)
+
+      assert {:ok, finalized} =
+               Accounting.finalize_failure(reserved.request, attempt, %{
+                 response_status_code: 499,
+                 last_error_code: "owner_unavailable",
+                 usage_status: "usage_unknown"
+               })
+
+      assert finalized.request.status == "failed"
+      assert finalized.attempt.status == "failed"
+
+      assert {:error, %{code: :request_already_finalized}} =
+               Accounting.record_retryable_attempt_failure(attempt, %{
+                 response_status_code: 499,
+                 last_error_code: "upstream_network_error"
+               })
+
+      assert {:error, %{code: :request_already_finalized}} =
+               Accounting.create_attempt(reserved.request, setup.assignment)
+
+      assert Repo.reload!(attempt).status == "failed"
+
+      assert Repo.aggregate(
+               from(a in Attempt, where: a.request_id == ^reserved.request.id),
+               :count,
+               :id
+             ) == 1
+    end
+
     test "late known usage replaces an unknown settlement and its projections" do
       setup = accounting_setup()
       first_timestamp = DateTime.utc_now() |> DateTime.truncate(:microsecond)
@@ -672,6 +713,64 @@ defmodule CodexPooler.AccountingTest do
                "reservation",
                "settlement"
              ]
+    end
+
+    test "recovers stale open attempts attached to terminal requests" do
+      setup = accounting_setup()
+      now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+
+      assert {:ok, reserved} =
+               Accounting.reserve(
+                 setup.auth,
+                 setup.model,
+                 %{"model" => setup.model.exposed_model_id, "max_output_tokens" => 10},
+                 %{correlation_id: "corr-terminal-orphan-attempt"}
+               )
+
+      assert {:ok, first_attempt} =
+               Accounting.create_attempt(reserved.request, setup.assignment)
+
+      assert {:ok, _finalized} =
+               Accounting.finalize_failure(reserved.request, first_attempt, %{
+                 response_status_code: 499,
+                 last_error_code: "owner_unavailable",
+                 usage_status: "usage_unknown"
+               })
+
+      orphaned_attempt =
+        %Attempt{
+          request_id: reserved.request.id,
+          attempt_number: 2,
+          pool_upstream_assignment_id: setup.assignment.id,
+          upstream_identity_id: setup.identity.id,
+          model_id: setup.model.id,
+          upstream_model_id: setup.model.upstream_model_id,
+          transport: reserved.request.transport,
+          status: "in_progress",
+          started_at: DateTime.add(now, -7, :hour),
+          retryable: false,
+          usage_status: "usage_pending",
+          response_metadata: %{}
+        }
+        |> Repo.insert!()
+
+      assert {:ok,
+              %{
+                stale_reservations_released: 0,
+                stale_reservations_settled: 0,
+                stale_terminal_attempts_recovered: 1
+              }} = Accounting.recover_stale_reservations(now)
+
+      recovered_attempt = Repo.reload!(orphaned_attempt)
+      assert recovered_attempt.status == "failed"
+      assert recovered_attempt.retryable == false
+      assert recovered_attempt.usage_status == "usage_unknown"
+      assert recovered_attempt.network_error_code == "terminal_request_attempt_recovered"
+      assert recovered_attempt.completed_at == now
+
+      fact = Repo.get_by!(RequestLogFact, request_id: reserved.request.id)
+      assert fact.latest_attempt_id == orphaned_attempt.id
+      assert fact.latest_attempt_status == "failed"
     end
 
     test "partial stream failure is accounted once and remains metadata-only" do

--- a/test/codex_pooler/gateway/runtime/streaming/stream_lifecycle_test.exs
+++ b/test/codex_pooler/gateway/runtime/streaming/stream_lifecycle_test.exs
@@ -15,6 +15,7 @@ defmodule CodexPooler.Gateway.Runtime.Streaming.StreamLifecycleTest do
   alias CodexPooler.Gateway.Payloads.RequestOptions
   alias CodexPooler.Gateway.Persistence.{BridgeDemotion, RoutingCircuitState}
   alias CodexPooler.Gateway.Routing.{BridgeRing, RoutePlanInput}
+  alias CodexPooler.Gateway.Runtime.Dispatch
 
   alias CodexPooler.Gateway.Runtime.Dispatch.{
     ResponseContext,
@@ -783,6 +784,87 @@ defmodule CodexPooler.Gateway.Runtime.Streaming.StreamLifecycleTest do
     assert updated.reason_code == "upstream_5xx"
     assert updated.failure_count == 3
     assert updated.success_count == 0
+    assert updated.metadata["probe_in_flight_count"] == 0
+  end
+
+  test "terminal request rejects a late candidate retry and releases its half-open probe" do
+    {setup, _first_upstream, _second_upstream} =
+      stream_retry_setup(
+        FakeUpstream.sse_stream([]),
+        FakeUpstream.sse_stream([])
+      )
+
+    {:ok, auth} = Access.authenticate_authorization_header(setup.authorization)
+    payload = payload(setup)
+    request_options = request_options(auth, payload, setup)
+    now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+
+    assert {:ok, reserved} =
+             Accounting.reserve(auth, setup.model, payload, %{
+               endpoint: @endpoint_path,
+               transport: "http_sse",
+               correlation_id:
+                 "terminal-request-attempt-fence-#{System.unique_integer([:positive])}",
+               request_metadata: %{}
+             })
+
+    assert {:ok, attempt} = Accounting.create_attempt(reserved.request, setup.assignment)
+
+    assert {:ok, finalized} =
+             Accounting.finalize_failure(reserved.request, attempt, %{
+               response_status_code: 499,
+               last_error_code: "owner_unavailable",
+               usage_status: "usage_unknown"
+             })
+
+    circuit =
+      %RoutingCircuitState{
+        pool_id: auth.pool.id,
+        pool_upstream_assignment_id: setup.assignment.id,
+        upstream_identity_id: setup.identity.id,
+        model_identifier: setup.model.exposed_model_id,
+        route_class: request_options.transport.route_class,
+        status: "half_open",
+        reason_code: "upstream_5xx",
+        failure_count: 3,
+        success_count: 0,
+        opened_at: DateTime.add(now, -120, :second),
+        half_opened_at: now,
+        metadata: %{"probe_in_flight_count" => 0},
+        created_at: DateTime.add(now, -120, :second),
+        updated_at: now
+      }
+      |> Repo.insert!()
+
+    context =
+      retry_context(setup, auth, request_options, finalized.request,
+        candidates: [{setup.assignment, setup.identity}],
+        attempt: nil
+      )
+
+    parent = self()
+
+    assert {:error,
+            %{
+              status: 499,
+              code: "request_already_finalized",
+              message: "request lifecycle completed before upstream dispatch"
+            }} =
+             Dispatch.dispatch_from(context, 0, fn _context ->
+               send(parent, :late_upstream_dispatch_called)
+               {:ok, %{status: 200}}
+             end)
+
+    refute_received :late_upstream_dispatch_called
+
+    assert Repo.aggregate(
+             from(a in Attempt, where: a.request_id == ^reserved.request.id),
+             :count,
+             :id
+           ) == 1
+
+    updated = Repo.reload!(circuit)
+    assert updated.status == "half_open"
     assert updated.metadata["probe_in_flight_count"] == 0
   end
 


### PR DESCRIPTION
## Summary

- Serialize upstream-attempt creation and retryable-attempt settlement with request finalization by locking the request row first.
- Reject late retry writes and late candidate dispatch after a request has reached a terminal lifecycle state.
- Release an acquired half-open routing-circuit probe when the request fence stops dispatch before an attempt is created.
- Recover stale queued or in-progress attempts that are attached to already-terminal requests.
- Refresh request-log facts when orphan attempts are recovered so admin/request-log projections match the repaired attempt state.

## Problem

Candidate retry and terminal finalization previously operated on stale structs without sharing a request-row fence. A retry could therefore create another upstream attempt, or mark an attempt retryable, after another path had already completed the request. That left terminal requests with open attempts and could strand a half-open circuit probe when dispatch was rejected late.

The existing stale-reservation recovery only scanned non-terminal requests. It could not repair an open attempt whose parent request was already succeeded, failed, rejected, or cancelled.

## Concurrency contract

RequestLifecycle.create_attempt/3 now:

1. starts a transaction;
2. locks the current request row FOR UPDATE;
3. verifies the request is accepted or in_progress and has no completed_at value;
4. computes the attempt number and inserts the attempt while still holding the request lock.

RequestLifecycle.record_retryable_attempt_failure/2 now:

1. locks the request row first;
2. verifies the request is still dispatchable;
3. locks the attempt row second, matching finalization lock order;
4. verifies the attempt is still queued or in_progress with no completed_at value before writing the retryable terminal state.

The shared lock ordering is request then attempt, matching request finalization and avoiding an inverted-lock deadlock.

Fence failures return explicit internal accounting codes:

- request_already_finalized
- attempt_already_finalized

The gateway maps those expected lifecycle races to a sanitized 499 response instead of reporting them as generic accounting failures.

## Circuit-probe cleanup

Dispatch opens or acquires candidate circuit state before it creates the accounting attempt. If attempt creation is fenced because the request already completed, Dispatch now records a neutral selection completion using the acquired circuit state. This releases any half-open probe and prevents probe_in_flight_count from remaining stranded.

## Orphan-attempt recovery

The existing stale-reservation job now performs a second bounded scan for:

- terminal requests: succeeded, failed, rejected, or cancelled;
- open attempts: queued or in_progress;
- attempts older than the configured stale cutoff.

Each candidate is reloaded under request-then-attempt row locks and rechecked before mutation. Still-open attempts are closed as failed with:

- network_error_code: terminal_request_attempt_recovered
- usage_status: usage_unknown
- retryable: false
- completed_at: the recovery timestamp

Concurrent or already-repaired rows become no-ops. The recovery summary adds stale_terminal_attempts_recovered, and request_log_facts is updated for every repaired attempt.

## Scope

This PR is intentionally limited to terminal request lifecycle fencing, circuit-probe cleanup, and orphan-attempt recovery. It does not include daily-rollup changes, model-unavailable failover, catalog sync, identity refresh recovery, or admin UI work.

## Verification

- mix test test/codex_pooler/accounting_test.exs test/codex_pooler/gateway/runtime/streaming/stream_lifecycle_test.exs
  - 40 passed
- mix compile --warnings-as-errors
  - passed
- mix credo --strict on all seven changed source/test files
  - no issues
- git diff --check
  - passed

The focused tests cover:

- terminal requests rejecting both late retryable updates and new attempts;
- stale open attempts on terminal requests being repaired and reflected in request-log facts;
- late candidate dispatch being stopped before transport invocation;
- half-open circuit probes being released when the terminal request fence wins.

## Deployment notes

No schema migration or configuration change is required. This PR does not deploy or modify Portainer.