### PR TITLE
fix(accounting): make daily rollup increments conflict-safe

### DIFF
--- a/lib/codex_pooler/accounting/usage/rollups.ex
+++ b/lib/codex_pooler/accounting/usage/rollups.ex
@@ -13,6 +13,18 @@ defmodule CodexPooler.Accounting.Rollups do
   @amount_recorded "recorded"
   @usage_known "usage_known"
   @unknown_model_code "Unknown model"
+  @daily_rollup_conflict_targets %{
+    "pool" => {:unsafe_fragment, "(rollup_date, pool_id) WHERE dimension_kind = 'pool'"},
+    "api_key" =>
+      {:unsafe_fragment, "(rollup_date, pool_id, api_key_id) WHERE dimension_kind = 'api_key'"},
+    "pool_upstream_assignment" =>
+      {:unsafe_fragment,
+       "(rollup_date, pool_upstream_assignment_id) WHERE dimension_kind = 'pool_upstream_assignment'"},
+    "upstream_identity" =>
+      {:unsafe_fragment,
+       "(rollup_date, upstream_identity_id) WHERE dimension_kind = 'upstream_identity'"},
+    "model" => {:unsafe_fragment, "(rollup_date, model_id) WHERE dimension_kind = 'model'"}
+  }
 
   @daily_rollup_rebuild_sql """
   WITH source AS MATERIALIZED (
@@ -660,22 +672,46 @@ defmodule CodexPooler.Accounting.Rollups do
 
   defp upsert_rollup!(identity, date, delta) do
     now = now()
-    existing = Repo.get_by(DailyRollup, rollup_lookup(identity, date))
 
-    attrs = Map.merge(identity, Map.merge(delta, %{rollup_date: date, updated_at: now}))
+    attrs =
+      identity
+      |> Map.merge(delta)
+      |> Map.merge(%{rollup_date: date, created_at: now, updated_at: now})
 
-    case existing do
-      %DailyRollup{} = rollup ->
-        rollup
-        |> Ecto.Changeset.change(add_rollup_attrs(rollup, delta, now))
-        |> Repo.update!()
+    Repo.insert_all(DailyRollup, [attrs],
+      on_conflict: daily_rollup_increment_conflict(delta, now),
+      conflict_target: daily_rollup_conflict_target(identity)
+    )
 
-      nil ->
-        attrs
-        |> Map.put(:created_at, now)
-        |> then(&struct(DailyRollup, &1))
-        |> Repo.insert!()
-    end
+    :ok
+  end
+
+  defp daily_rollup_conflict_target(%{dimension_kind: dimension_kind}) do
+    Map.fetch!(@daily_rollup_conflict_targets, dimension_kind)
+  end
+
+  defp daily_rollup_increment_conflict(delta, now) do
+    from rollup in DailyRollup,
+      update: [
+        set: [
+          estimated_cost_micros:
+            fragment("? + EXCLUDED.estimated_cost_micros", rollup.estimated_cost_micros),
+          settled_cost_micros:
+            fragment("? + EXCLUDED.settled_cost_micros", rollup.settled_cost_micros),
+          updated_at: ^now
+        ],
+        inc: [
+          request_count: ^delta.request_count,
+          success_count: ^delta.success_count,
+          failure_count: ^delta.failure_count,
+          retry_count: ^delta.retry_count,
+          input_tokens: ^delta.input_tokens,
+          cached_input_tokens: ^delta.cached_input_tokens,
+          output_tokens: ^delta.output_tokens,
+          reasoning_tokens: ^delta.reasoning_tokens,
+          total_tokens: ^delta.total_tokens
+        ]
+      ]
   end
 
   defp subtract_rollup!(identity, date, delta) do
@@ -687,24 +723,6 @@ defmodule CodexPooler.Accounting.Rollups do
     else
       rollup |> Ecto.Changeset.change(attrs) |> Repo.update!()
     end
-  end
-
-  defp add_rollup_attrs(rollup, delta, timestamp) do
-    %{
-      request_count: rollup.request_count + delta.request_count,
-      success_count: rollup.success_count + delta.success_count,
-      failure_count: rollup.failure_count + delta.failure_count,
-      retry_count: rollup.retry_count + delta.retry_count,
-      input_tokens: rollup.input_tokens + delta.input_tokens,
-      cached_input_tokens: rollup.cached_input_tokens + delta.cached_input_tokens,
-      output_tokens: rollup.output_tokens + delta.output_tokens,
-      reasoning_tokens: rollup.reasoning_tokens + delta.reasoning_tokens,
-      total_tokens: rollup.total_tokens + delta.total_tokens,
-      estimated_cost_micros:
-        Decimal.add(rollup.estimated_cost_micros, delta.estimated_cost_micros),
-      settled_cost_micros: Decimal.add(rollup.settled_cost_micros, delta.settled_cost_micros),
-      updated_at: timestamp
-    }
   end
 
   defp subtract_rollup_attrs(rollup, delta, timestamp) do

--- a/priv/repo/migrations/20260713161500_scope_daily_api_key_rollups_by_pool.exs
+++ b/priv/repo/migrations/20260713161500_scope_daily_api_key_rollups_by_pool.exs
@@ -1,0 +1,28 @@
+defmodule CodexPooler.Repo.Migrations.ScopeDailyApiKeyRollupsByPool do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up do
+    # A failed CREATE INDEX CONCURRENTLY can leave an invalid index behind.
+    # Remove the staging name first so a migration retry rebuilds it instead
+    # of letting IF NOT EXISTS silently accept an unusable index.
+    execute("DROP INDEX CONCURRENTLY IF EXISTS public.daily_rollups_api_key_pool_uq")
+
+    execute("""
+    CREATE UNIQUE INDEX CONCURRENTLY daily_rollups_api_key_pool_uq
+    ON public.daily_rollups USING btree (rollup_date, pool_id, api_key_id)
+    WHERE dimension_kind = 'api_key'::text
+    """)
+
+    execute("DROP INDEX CONCURRENTLY IF EXISTS public.daily_rollups_api_key_uq")
+
+    execute("ALTER INDEX public.daily_rollups_api_key_pool_uq RENAME TO daily_rollups_api_key_uq")
+  end
+
+  def down do
+    raise Ecto.MigrationError,
+          "daily API-key rollups cannot be collapsed across pools without losing attribution"
+  end
+end

--- a/test/codex_pooler/accounting_test.exs
+++ b/test/codex_pooler/accounting_test.exs
@@ -801,6 +801,100 @@ defmodule CodexPooler.AccountingTest do
       assert rollup.total_tokens == 24
     end
 
+    test "API key moved between pools keeps a separate daily rollup for each pool" do
+      setup = accounting_setup()
+      other_pool = pool_fixture()
+
+      first_request =
+        request_fixture(%{pool: setup.pool, api_key: setup.api_key}, %{
+          correlation_id: "api-key-before-pool-move"
+        })
+
+      moved_api_key =
+        setup.api_key
+        |> Ecto.Changeset.change(pool_id: other_pool.id)
+        |> Repo.update!()
+
+      second_request =
+        request_fixture(%{pool: other_pool, api_key: moved_api_key}, %{
+          correlation_id: "api-key-after-pool-move"
+        })
+
+      first_settlement = ledger_entry_fixture(first_request, %{total_tokens: 11})
+      second_settlement = ledger_entry_fixture(second_request, %{total_tokens: 13})
+
+      assert :ok = Rollups.accumulate!(first_request, first_settlement)
+      assert :ok = Rollups.accumulate!(second_request, second_settlement)
+
+      date = DateTime.to_date(first_settlement.occurred_at)
+
+      expected =
+        Enum.sort([
+          {setup.pool.id, 1, 11},
+          {other_pool.id, 1, 13}
+        ])
+
+      assert api_key_rollup_summaries(date, setup.api_key.id) == expected
+
+      assert {:ok, 2} = Accounting.rebuild_daily_rollups_for_date(date)
+      assert api_key_rollup_summaries(date, setup.api_key.id) == expected
+    end
+
+    test "incremental daily rollups use atomic conflict-safe increments" do
+      setup = accounting_setup()
+
+      request_settlements =
+        for index <- 1..2 do
+          request =
+            request_fixture(%{pool: setup.pool, api_key: setup.api_key}, %{
+              correlation_id: "atomic-daily-rollup-#{index}",
+              model_id: setup.model.id,
+              requested_model: setup.model.exposed_model_id
+            })
+
+          settlement =
+            ledger_entry_fixture(request, %{
+              pool_upstream_assignment_id: setup.assignment.id,
+              upstream_identity_id: setup.identity.id,
+              input_tokens: 7,
+              cached_input_tokens: 3,
+              output_tokens: 5,
+              reasoning_tokens: 2,
+              total_tokens: 12,
+              estimated_cost_micros: 11,
+              settled_cost_micros: 9
+            })
+
+          {request, settlement}
+        end
+
+      {results, commands} =
+        count_repo_commands(fn ->
+          Enum.map(request_settlements, fn {request, settlement} ->
+            Rollups.accumulate!(request, settlement)
+          end)
+        end)
+
+      assert results == [:ok, :ok]
+      assert command_count(commands, "daily_rollups", "SELECT") == 0
+      assert command_count(commands, "daily_rollups", "UPDATE") == 0
+      assert command_count(commands, "daily_rollups", "INSERT") == 10
+
+      date =
+        request_settlements |> hd() |> elem(1) |> Map.fetch!(:occurred_at) |> DateTime.to_date()
+
+      rollups = daily_rollup_rows(date)
+
+      assert Enum.map(rollups, & &1.dimension_kind) |> Enum.sort() ==
+               Enum.sort(daily_rollup_dimensions())
+
+      assert Enum.all?(rollups, &(&1.request_count == 2))
+      assert Enum.all?(rollups, &(&1.total_tokens == 24))
+      assert Enum.all?(rollups, &(&1.cached_input_tokens == 6))
+      assert Enum.all?(rollups, &(&1.estimated_cost_micros == "22"))
+      assert Enum.all?(rollups, &(&1.settled_cost_micros == "18"))
+    end
+
     @tag :daily_rollup_rebuild_set_based_correctness
     test "daily rollup rebuild matches incremental rollups across every dimension" do
       date = ~D[2026-05-31]
@@ -1195,6 +1289,18 @@ defmodule CodexPooler.AccountingTest do
     |> Repo.all()
     |> Enum.map(&daily_rollup_row/1)
     |> Enum.sort_by(&daily_rollup_sort_key/1)
+  end
+
+  defp api_key_rollup_summaries(date, api_key_id) do
+    DailyRollup
+    |> where(
+      [rollup],
+      rollup.rollup_date == ^date and rollup.dimension_kind == "api_key" and
+        rollup.api_key_id == ^api_key_id
+    )
+    |> Repo.all()
+    |> Enum.map(&{&1.pool_id, &1.request_count, &1.total_tokens})
+    |> Enum.sort()
   end
 
   defp daily_rollup_row(%DailyRollup{} = rollup) do

--- a/test/codex_pooler/schema_contract_test.exs
+++ b/test/codex_pooler/schema_contract_test.exs
@@ -128,6 +128,7 @@ defmodule CodexPooler.SchemaContractTest do
           "ledger_entries_api_key_recorded_occurred_idx",
           "request_log_facts_latest_upstream_identity_request_idx",
           "requests_admitted_id_idx",
+          "daily_rollups_api_key_uq",
           "daily_rollups_pool_uq",
           "hourly_model_usage_rollups_bucket_pool_model_code_uq",
           "hourly_model_usage_rollups_pool_bucket_model_idx",
@@ -174,6 +175,12 @@ defmodule CodexPooler.SchemaContractTest do
 
     assert indexes["request_log_facts_latest_upstream_identity_request_idx"] =~
              "WHERE (latest_upstream_identity_id IS NOT NULL)"
+
+    assert indexes["daily_rollups_api_key_uq"] =~
+             "(rollup_date, pool_id, api_key_id)"
+
+    assert indexes["daily_rollups_api_key_uq"] =~
+             "WHERE (dimension_kind = 'api_key'::text)"
 
     assert indexes["hourly_model_usage_rollups_bucket_pool_model_code_uq"] =~
              "(bucket_started_at, pool_id, model_code)"


### PR DESCRIPTION
## Summary

- Replace daily-rollup read/modify/write accumulation with one PostgreSQL INSERT ... ON CONFLICT DO UPDATE operation per rollup dimension.
- Increment counters, token totals, and monetary totals inside the conflict update so concurrent settlements cannot overwrite each other.
- Scope API-key daily-rollup uniqueness by pool as well as date and API key.
- Keep set-based daily rebuilds consistent with incremental rollups when an API key has historical requests in more than one pool.
- Add schema-contract coverage for the new partial unique-index definition.

## Problem

Daily rollup accumulation previously performed:

1. SELECT the existing rollup row;
2. calculate totals in application memory;
3. UPDATE the row, or INSERT when it did not exist.

Two settlements for the same pool/date/dimension could read the same totals and then overwrite each other, losing one settlement. Two first writers could also race on the insert path.

The API-key partial unique index was defined as rollup_date plus api_key_id. Requests retain their historical pool_id, so moving or reattaching an API key to another pool caused daily usage from both pools to collide in one API-key rollup identity. Incremental accumulation and the set-based rebuild did not have a uniqueness definition capable of retaining both pool attributions.

## Atomic accumulation

Rollups now use Repo.insert_all with a dimension-specific partial-index conflict target.

For existing rows, PostgreSQL performs the following within the conflicting row update:

- integer request/success/failure/retry counters are incremented;
- input, cached-input, output, reasoning, and total token counters are incremented;
- estimated and settled cost values are updated as current value plus EXCLUDED value;
- updated_at is refreshed without replacing created_at.

Conflict targets cover all existing daily dimensions:

- pool: rollup_date, pool_id
- API key: rollup_date, pool_id, api_key_id
- assignment: rollup_date, pool_upstream_assignment_id
- upstream identity: rollup_date, upstream_identity_id
- model: rollup_date, model_id

The existing partial-index predicates remain part of each target, so unrelated dimension rows cannot collide.

## API-key uniqueness migration

The migration builds the replacement unique index concurrently while the old, stronger index remains active:

- new key: rollup_date, pool_id, api_key_id
- predicate: dimension_kind = 'api_key'

After the concurrent build succeeds, it drops the old index concurrently and renames the replacement to preserve the established index name.

CREATE INDEX CONCURRENTLY can leave an invalid index when interrupted. The migration removes the staging index name before building it, so a migration retry cannot let IF NOT EXISTS silently accept an invalid index.

The down direction is intentionally rejected. Once one API key has separate same-day rows in multiple pools, restoring the two-column uniqueness rule would require collapsing attributed usage and would lose pool provenance.

## Regression coverage

The tests prove that:

- an API key moved between pools retains one API-key rollup per pool for the same date;
- the set-based rebuild reproduces the same pool-scoped rows;
- two incremental settlements execute only conflict-safe daily-rollup INSERT statements, with no daily-rollup SELECT or UPDATE commands;
- all five dimensions receive the summed request, token, and cost totals;
- the installed schema exposes daily_rollups_api_key_uq over rollup_date, pool_id, api_key_id with the API-key partial predicate.

## Scope

This PR is intentionally limited to daily-rollup accumulation and API-key rollup uniqueness. It does not include terminal request lifecycle fencing, model-unavailable failover, catalog synchronization, identity recovery, or admin UI changes.

## Verification

- mix test test/codex_pooler/accounting_test.exs test/codex_pooler/schema_contract_test.exs
  - 37 passed
- mix compile --warnings-as-errors
  - passed
- mix credo --strict on all four changed source/migration/test files
  - no issues
- git diff --check
  - passed

## Deployment notes

This PR includes one online PostgreSQL index migration. It disables the DDL transaction and migration lock because CREATE/DROP INDEX CONCURRENTLY cannot run inside a transaction. Run migrations from one release process as usual.

No application configuration or Portainer change is included, and this PR has not been deployed.