### PR TITLE
fix(gateway): fail over unavailable models across transports

### DIFF
--- a/lib/codex_pooler/gateway/runtime/dispatch/upstream_attempt.ex
+++ b/lib/codex_pooler/gateway/runtime/dispatch/upstream_attempt.ex
@@ -64,6 +64,7 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch.UpstreamAttempt do
   defp finalization_callbacks(callbacks) do
     %{
       register_continuity: Map.fetch!(callbacks, :register_continuity),
+      retry_dispatch: Map.fetch!(callbacks, :retry_dispatch),
       stream_result: fn response, context ->
         StreamDispatch.streaming_result(response, context, %{
           finalization_callbacks: finalization_callbacks(callbacks),

--- a/lib/codex_pooler/gateway/runtime/dispatch/websocket_attempt.ex
+++ b/lib/codex_pooler/gateway/runtime/dispatch/websocket_attempt.ex
@@ -3,10 +3,16 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch.WebsocketAttempt do
 
   alias CodexPooler.Accounting
   alias CodexPooler.Accounting.FailureResponse
-  alias CodexPooler.Gateway.Runtime.Dispatch.PreparedContext
-  alias CodexPooler.Gateway.Runtime.Dispatch.ResponseContext
+
+  alias CodexPooler.Gateway.Runtime.Dispatch.{
+    CandidateDispatch,
+    PreparedContext,
+    ResponseContext
+  }
+
   alias CodexPooler.Gateway.Runtime.Finalization
   alias CodexPooler.Gateway.Runtime.Finalization.{AttemptSettlement, Metadata}
+  alias CodexPooler.Gateway.Runtime.ModelUnavailable
   alias CodexPooler.Gateway.Transports.Streaming.StreamProtocol
   alias CodexPooler.Gateway.Transports.Streaming.WebsocketCodec
   alias CodexPooler.Gateway.Transports.UpstreamDispatch
@@ -35,6 +41,7 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch.WebsocketAttempt do
 
   @type callbacks :: %{
           required(:register_continuity) => (term(), term(), term() -> term()),
+          required(:retry_dispatch) => (PreparedContext.t() -> dispatch_result()),
           required(:stream_result) => (Req.Response.t(), term() -> term())
         }
   @type dispatch_result :: CodexPooler.Gateway.Runtime.Dispatch.dispatch_result()
@@ -73,8 +80,10 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch.WebsocketAttempt do
           started
         )
 
-      {:error, %{reason: {:retryable_first_event, failure}} = response} ->
-        handle_retryable_first_websocket_event(
+      {:error, %{reason: {kind, failure}} = response}
+      when kind in [:retryable_first_event, :model_unavailable_first_event] ->
+        handle_pre_visible_terminal_websocket_event(
+          kind,
           prepared_context,
           dispatch_request,
           callbacks,
@@ -266,6 +275,89 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch.WebsocketAttempt do
     deliver_retry_exhausted_websocket_failure(dispatch_request, response)
 
     response_context = retryable_websocket_response_context(context, response)
+
+    Finalization.finalize_first_event_stream_failure(
+      Map.get(response, :body, ""),
+      failure,
+      response_context
+    )
+  end
+
+  defp handle_pre_visible_terminal_websocket_event(
+         :retryable_first_event,
+         prepared_context,
+         dispatch_request,
+         callbacks,
+         response,
+         failure
+       ) do
+    handle_retryable_first_websocket_event(
+      prepared_context,
+      dispatch_request,
+      callbacks,
+      response,
+      failure
+    )
+  end
+
+  defp handle_pre_visible_terminal_websocket_event(
+         :model_unavailable_first_event,
+         prepared_context,
+         dispatch_request,
+         callbacks,
+         response,
+         failure
+       ) do
+    handle_model_unavailable_websocket_event(
+      prepared_context,
+      dispatch_request,
+      callbacks,
+      response,
+      failure
+    )
+  end
+
+  defp handle_model_unavailable_websocket_event(
+         %PreparedContext{context: context},
+         dispatch_request,
+         callbacks,
+         response,
+         failure
+       ) do
+    response_context = retryable_websocket_response_context(context, response)
+
+    if ModelUnavailable.retryable_failure?(failure, context) do
+      next_index = context.retry_count + 1
+
+      with {:ok, _recorded_failure} <-
+             Finalization.record_retryable_first_event_stream_failure(
+               Map.get(response, :body, ""),
+               failure,
+               response_context
+             ) do
+        CandidateDispatch.dispatch_from(
+          context,
+          next_index,
+          Map.fetch!(callbacks, :retry_dispatch)
+        )
+      end
+    else
+      finalize_model_unavailable_websocket_failure(
+        dispatch_request,
+        response,
+        failure,
+        response_context
+      )
+    end
+  end
+
+  defp finalize_model_unavailable_websocket_failure(
+         dispatch_request,
+         response,
+         failure,
+         response_context
+       ) do
+    deliver_retry_exhausted_websocket_failure(dispatch_request, response)
 
     Finalization.finalize_first_event_stream_failure(
       Map.get(response, :body, ""),

--- a/lib/codex_pooler/gateway/runtime/finalization/finalization.ex
+++ b/lib/codex_pooler/gateway/runtime/finalization/finalization.ex
@@ -5,6 +5,7 @@ defmodule CodexPooler.Gateway.Runtime.Finalization do
 
   alias CodexPooler.Gateway.Runtime.Dispatch.ResponseContext
   alias CodexPooler.Gateway.Runtime.Dispatch.SelectedCandidateContext
+  alias CodexPooler.Gateway.Runtime.ModelUnavailable
   alias CodexPooler.Gateway.Runtime.RateLimitObserver
   alias CodexPooler.Gateway.Runtime.Streaming.Types, as: StreamTypes
 
@@ -112,7 +113,7 @@ defmodule CodexPooler.Gateway.Runtime.Finalization do
   end
 
   def handle_http_response(
-        %Req.Response{status: status} = response,
+        %Req.Response{} = response,
         %SelectedCandidateContext{} = context,
         _callbacks
       ) do
@@ -126,6 +127,20 @@ defmodule CodexPooler.Gateway.Runtime.Finalization do
       body = Metadata.response_body(response)
       RateLimitObserver.record_error(identity, body)
 
+      finalize_non_retryable_http_status(response, context, body)
+    end
+  end
+
+  defp finalize_non_retryable_http_status(
+         %Req.Response{status: status} = response,
+         %SelectedCandidateContext{} = context,
+         body
+       ) do
+    if ModelUnavailable.http_error?(status, body, context) do
+      with :ok <- record_dispatch_route_failure("model_unavailable", context) do
+        finalize_model_unavailable_or_failure(response, context, body)
+      end
+    else
       with :ok <- maybe_record_unauthorized_route_failure(status, context) do
         finalize_upstream_status_failure(response, context, body)
       end
@@ -271,6 +286,30 @@ defmodule CodexPooler.Gateway.Runtime.Finalization do
       finalize_upstream_status_failure(response, context, body,
         attempt_status: if(allow_retry?, do: "retryable_failed", else: "failed")
       )
+    end
+  end
+
+  defp finalize_model_unavailable_or_failure(
+         %Req.Response{status: status} = response,
+         %SelectedCandidateContext{} = context,
+         body
+       ) do
+    %{reserved: reserved, attempt: attempt, request_options: request_options} = context
+
+    if ModelUnavailable.failover_allowed?(context) do
+      case AttemptSettlement.record_retryable_failure(reserved.request, attempt, %{
+             response_status_code: status,
+             last_error_code: "model_unavailable",
+             error_message: "model is not available on this assignment",
+             latency_ms: elapsed_ms(context.started),
+             attempt_metadata:
+               Metadata.response_metadata(response, "model_unavailable", request_options)
+           }) do
+        {:ok, _attempt} -> {:retry, :model_unavailable}
+        {:error, gateway_error} -> {:error, gateway_error}
+      end
+    else
+      finalize_upstream_status_failure(response, context, body, attempt_status: "failed")
     end
   end
 

--- a/lib/codex_pooler/gateway/runtime/model_unavailable.ex
+++ b/lib/codex_pooler/gateway/runtime/model_unavailable.ex
@@ -1,0 +1,142 @@
+defmodule CodexPooler.Gateway.Runtime.ModelUnavailable do
+  @moduledoc false
+
+  alias CodexPooler.Catalog.Model
+  alias CodexPooler.Gateway.Payloads.RequestOptions
+  alias CodexPooler.Gateway.Routing.SessionContinuity
+  alias CodexPooler.Gateway.Runtime.Dispatch.SelectedCandidateContext
+
+  @compact_endpoint "/backend-api/codex/responses/compact"
+  @invalid_request_error "invalid_request_error"
+  @model_not_found "model_not_found"
+
+  @spec http_error?(non_neg_integer(), binary(), SelectedCandidateContext.t()) :: boolean()
+  def http_error?(status, body, %SelectedCandidateContext{} = context)
+      when is_integer(status) and is_binary(body) do
+    with {:ok, decoded} when is_map(decoded) <- Jason.decode(body),
+         error when is_map(error) <- error_payload(decoded) do
+      explicit_model_not_found?(error) or
+        (status == 404 and ambiguous_model_error?(error) and catalog_provenance?(context))
+    else
+      _invalid_or_unrelated -> false
+    end
+  end
+
+  def http_error?(_status, _body, _context), do: false
+
+  @spec failure_signature?(map()) :: boolean()
+  def failure_signature?(failure) when is_map(failure) do
+    explicit_model_not_found?(failure) or ambiguous_model_error?(failure)
+  end
+
+  def failure_signature?(_failure), do: false
+
+  @spec failure?(map(), SelectedCandidateContext.t()) :: boolean()
+  def failure?(failure, %SelectedCandidateContext{} = context) when is_map(failure) do
+    explicit_model_not_found?(failure) or
+      (ambiguous_model_error?(failure) and catalog_provenance?(context))
+  end
+
+  def failure?(_failure, _context), do: false
+
+  @spec retryable_failure?(map(), SelectedCandidateContext.t()) :: boolean()
+  def retryable_failure?(failure, %SelectedCandidateContext{} = context) do
+    failure?(failure, context) and failover_allowed?(context)
+  end
+
+  def retryable_failure?(_failure, _context), do: false
+
+  @spec failover_allowed?(SelectedCandidateContext.t()) :: boolean()
+  def failover_allowed?(
+        %SelectedCandidateContext{
+          allow_retry?: true,
+          endpoint: endpoint
+        } = context
+      ) do
+    endpoint != @compact_endpoint and not hard_pinned?(context)
+  end
+
+  def failover_allowed?(%SelectedCandidateContext{}), do: false
+
+  defp explicit_model_not_found?(error) do
+    codes = primary_error_codes(error)
+
+    @model_not_found in codes or
+      (codes == [] and @model_not_found in type_codes(error))
+  end
+
+  defp ambiguous_model_error?(error) do
+    codes = primary_error_codes(error)
+
+    invalid_request_error? =
+      @invalid_request_error in codes or
+        (codes == [] and @invalid_request_error in type_codes(error))
+
+    invalid_request_error? and error_param(error) == "model"
+  end
+
+  defp primary_error_codes(error) do
+    [map_value(error, :code), map_value(error, :upstream_code)]
+    |> Enum.flat_map(&nested_codes/1)
+    |> Enum.reject(&(&1 in [nil, ""]))
+  end
+
+  defp type_codes(error) do
+    error
+    |> map_value(:type)
+    |> nested_codes()
+    |> Enum.reject(&(&1 in [nil, ""]))
+  end
+
+  defp nested_codes(value) when is_binary(value), do: [value]
+
+  defp nested_codes(value) when is_map(value) do
+    [map_value(value, :code), map_value(value, :type)]
+    |> Enum.filter(&is_binary/1)
+  end
+
+  defp nested_codes(_value), do: []
+
+  defp error_param(error) do
+    map_value(error, :upstream_error_param) || map_value(error, :param)
+  end
+
+  defp error_payload(decoded) do
+    case map_value(decoded, :error) do
+      error when is_map(error) -> error
+      _missing -> nested_error_payload(decoded)
+    end
+  end
+
+  defp nested_error_payload(decoded) do
+    get_in(decoded, ["response", "error"]) ||
+      get_in(decoded, ["response", "status_details", "error"]) ||
+      get_in(decoded, ["status_details", "error"])
+  end
+
+  defp catalog_provenance?(%SelectedCandidateContext{
+         assignment: %{id: assignment_id},
+         model: %Model{} = model
+       })
+       when is_binary(assignment_id) do
+    case get_in(model.metadata || %{}, ["source_assignment_ids"]) do
+      assignment_ids when is_list(assignment_ids) -> assignment_id in assignment_ids
+      _missing -> false
+    end
+  end
+
+  defp catalog_provenance?(%SelectedCandidateContext{}), do: false
+
+  defp hard_pinned?(%SelectedCandidateContext{
+         request_options: %RequestOptions{} = request_options,
+         model: %Model{} = model
+       }) do
+    not is_nil(SessionContinuity.hard_pin_metadata(request_options, model))
+  end
+
+  defp hard_pinned?(%SelectedCandidateContext{}), do: false
+
+  defp map_value(map, key) when is_map(map) and is_atom(key) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+end

--- a/lib/codex_pooler/gateway/runtime/streaming/stream_attempt.ex
+++ b/lib/codex_pooler/gateway/runtime/streaming/stream_attempt.ex
@@ -3,6 +3,7 @@ defmodule CodexPooler.Gateway.Runtime.Streaming.StreamAttempt do
   Tracks and classifies the first SSE event for a streaming gateway attempt.
   """
 
+  alias CodexPooler.Gateway.Runtime.ModelUnavailable
   alias CodexPooler.Gateway.Runtime.Streaming.BufferTelemetry
   alias CodexPooler.Gateway.Transports.Streaming.StreamProtocol
 
@@ -19,14 +20,16 @@ defmodule CodexPooler.Gateway.Runtime.Streaming.StreamAttempt do
   @spec first_event_state() :: first_event_state()
   def first_event_state, do: %{classified?: false, buffer: ""}
 
-  @spec classify_first_event(binary(), first_event_state()) ::
+  @spec classify_first_event(binary(), first_event_state(), term() | nil) ::
           {classification(), first_event_state()}
-  def classify_first_event(data, %{classified?: classified?, buffer: buffer} = state)
+  def classify_first_event(data, state, context \\ nil)
+
+  def classify_first_event(data, %{classified?: classified?, buffer: buffer} = state, context)
       when is_binary(data) and is_binary(buffer) do
     if classified? do
       classify_data_after_first_event(data)
     else
-      classify_data_before_first_event(data, state)
+      classify_data_before_first_event(data, state, context)
     end
   end
 
@@ -43,11 +46,11 @@ defmodule CodexPooler.Gateway.Runtime.Streaming.StreamAttempt do
     {classification, %{classified?: true, buffer: ""}}
   end
 
-  defp classify_data_before_first_event(data, %{buffer: buffer}) do
+  defp classify_data_before_first_event(data, %{buffer: buffer}, context) do
     buffer = buffer <> data
 
     case StreamProtocol.first_complete_event(buffer) do
-      {:ok, event} -> classify_complete_first_event(buffer, event)
+      {:ok, event} -> classify_complete_first_event(buffer, event, context)
       :incomplete -> classify_incomplete_first_event(buffer)
     end
   end
@@ -66,14 +69,29 @@ defmodule CodexPooler.Gateway.Runtime.Streaming.StreamAttempt do
     end
   end
 
-  defp classify_complete_first_event(buffer, event) do
+  defp classify_complete_first_event(buffer, event, context) do
     classification =
       case StreamProtocol.retryable_first_terminal_failure(event) do
-        {:ok, failure} -> {:retry, failure}
-        :error -> classify_non_retryable_first_event(buffer, event)
+        {:ok, failure} ->
+          {:retry, failure}
+
+        :error ->
+          classify_model_unavailable_or_terminal(buffer, event, context)
       end
 
     {classification, classify_complete_first_event_state(event)}
+  end
+
+  defp classify_model_unavailable_or_terminal(buffer, event, context) do
+    case StreamProtocol.terminal_failure_event(event) do
+      {:ok, failure} ->
+        if ModelUnavailable.retryable_failure?(failure, context),
+          do: {:retry, failure},
+          else: classify_non_retryable_first_event(buffer, event)
+
+      _not_terminal ->
+        classify_non_retryable_first_event(buffer, event)
+    end
   end
 
   defp classify_non_retryable_first_event(buffer, event) do

--- a/lib/codex_pooler/gateway/runtime/streaming/stream_dispatch.ex
+++ b/lib/codex_pooler/gateway/runtime/streaming/stream_dispatch.ex
@@ -206,7 +206,11 @@ defmodule CodexPooler.Gateway.Runtime.Streaming.StreamDispatch do
     fn conn, data ->
       if sse_response?(response) do
         {classification, first_event_state} =
-          StreamAttempt.classify_first_event(data, first_event_state(conn))
+          StreamAttempt.classify_first_event(
+            data,
+            first_event_state(conn),
+            response_context.context
+          )
 
         conn = put_first_event_state(conn, first_event_state)
 

--- a/lib/codex_pooler/gateway/transports/websocket/upstream_websocket_session.ex
+++ b/lib/codex_pooler/gateway/transports/websocket/upstream_websocket_session.ex
@@ -3,6 +3,7 @@ defmodule CodexPooler.Gateway.Transports.Websocket.UpstreamWebsocketSession do
 
   use GenServer
 
+  alias CodexPooler.Gateway.Runtime.ModelUnavailable
   alias CodexPooler.Gateway.Transports.Streaming.RetainedBody
   alias CodexPooler.Gateway.Transports.Streaming.StreamProtocol
   alias CodexPooler.Gateway.Transports.Streaming.StreamProtocol.UpstreamErrorParam
@@ -603,7 +604,14 @@ defmodule CodexPooler.Gateway.Transports.Websocket.UpstreamWebsocketSession do
   defp retryable_pre_visible_terminal_event(event) do
     case StreamProtocol.auth_refresh_first_terminal_failure(event) do
       {:ok, failure} -> {:ok, {:auth_refresh_first_event, failure}}
-      :error -> retryable_connection_limit_event(event)
+      :error -> retryable_non_auth_terminal_event(event)
+    end
+  end
+
+  defp retryable_non_auth_terminal_event(event) do
+    case retryable_connection_limit_event(event) do
+      {:ok, result} -> {:ok, result}
+      :error -> model_unavailable_event(event)
     end
   end
 
@@ -613,6 +621,18 @@ defmodule CodexPooler.Gateway.Transports.Websocket.UpstreamWebsocketSession do
         {:ok, {:retryable_first_event, failure}}
 
       _other ->
+        :error
+    end
+  end
+
+  defp model_unavailable_event(event) do
+    case StreamProtocol.terminal_failure_event(event) do
+      {:ok, failure} ->
+        if ModelUnavailable.failure_signature?(failure),
+          do: {:ok, {:model_unavailable_first_event, failure}},
+          else: :error
+
+      _not_terminal ->
         :error
     end
   end

--- a/test/codex_pooler/gateway/runtime/model_unavailable_test.exs
+++ b/test/codex_pooler/gateway/runtime/model_unavailable_test.exs
@@ -1,0 +1,211 @@
+defmodule CodexPooler.Gateway.Runtime.ModelUnavailableTest do
+  use ExUnit.Case, async: true
+
+  alias CodexPooler.Catalog.Model
+  alias CodexPooler.Gateway.Payloads.RequestOptions
+  alias CodexPooler.Gateway.Runtime.Dispatch.SelectedCandidateContext
+  alias CodexPooler.Gateway.Runtime.ModelUnavailable
+  alias CodexPooler.Gateway.Runtime.Streaming.StreamAttempt
+  alias CodexPooler.Upstreams.Schemas.PoolUpstreamAssignment
+
+  @endpoint "/backend-api/codex/responses"
+
+  setup do
+    assignment_id = Ecto.UUID.generate()
+
+    context =
+      selected_context(assignment_id,
+        source_assignment_ids: [assignment_id]
+      )
+
+    %{context: context}
+  end
+
+  describe "http_error?/3" do
+    test "recognizes explicit model_not_found codes", %{context: context} do
+      body =
+        Jason.encode!(%{
+          "error" => %{
+            "code" => "model_not_found",
+            "message" => "model is not installed",
+            "type" => "invalid_request_error"
+          }
+        })
+
+      assert ModelUnavailable.http_error?(400, body, context)
+      assert ModelUnavailable.http_error?(404, body, context)
+    end
+
+    test "recognizes ambiguous 404 model errors only with catalog provenance", %{
+      context: context
+    } do
+      body =
+        Jason.encode!(%{
+          "error" => %{
+            "type" => "invalid_request_error",
+            "param" => "model",
+            "message" => "model is not available for this account"
+          }
+        })
+
+      assert ModelUnavailable.http_error?(404, body, context)
+      refute ModelUnavailable.http_error?(400, body, context)
+
+      without_provenance =
+        selected_context(context.assignment.id,
+          source_assignment_ids: [Ecto.UUID.generate()]
+        )
+
+      refute ModelUnavailable.http_error?(404, body, without_provenance)
+    end
+
+    test "does not reclassify unrelated or malformed errors", %{context: context} do
+      unrelated =
+        Jason.encode!(%{
+          "error" => %{"type" => "invalid_request_error", "param" => "input"}
+        })
+
+      conflicting_code =
+        Jason.encode!(%{
+          "error" => %{
+            "code" => "unrelated_invalid_request",
+            "type" => "invalid_request_error",
+            "param" => "model"
+          }
+        })
+
+      refute ModelUnavailable.http_error?(404, unrelated, context)
+      refute ModelUnavailable.http_error?(404, conflicting_code, context)
+      refute ModelUnavailable.http_error?(404, "not-json", context)
+    end
+  end
+
+  describe "retry policy" do
+    test "allows explicit model failures when another candidate is available", %{context: context} do
+      assert ModelUnavailable.retryable_failure?(model_not_found_failure(), context)
+    end
+
+    test "requires provenance for ambiguous invalid-request model failures", %{
+      context: context
+    } do
+      failure = invalid_request_model_failure()
+      assert ModelUnavailable.retryable_failure?(failure, context)
+
+      without_provenance =
+        selected_context(context.assignment.id,
+          source_assignment_ids: [Ecto.UUID.generate()]
+        )
+
+      refute ModelUnavailable.retryable_failure?(failure, without_provenance)
+      assert ModelUnavailable.failure_signature?(failure)
+    end
+
+    test "blocks exhausted, compact, and hard-pinned failover", %{context: context} do
+      refute ModelUnavailable.retryable_failure?(
+               model_not_found_failure(),
+               %{context | allow_retry?: false}
+             )
+
+      refute ModelUnavailable.retryable_failure?(
+               model_not_found_failure(),
+               %{context | endpoint: "/backend-api/codex/responses/compact"}
+             )
+
+      hard_pinned_options =
+        RequestOptions.build(
+          %{previous_response_id: "resp_hard_pin"},
+          @endpoint,
+          %{"model" => "synthetic-model", "previous_response_id" => "resp_hard_pin"}
+        )
+
+      refute ModelUnavailable.retryable_failure?(
+               model_not_found_failure(),
+               %{context | request_options: hard_pinned_options}
+             )
+    end
+  end
+
+  describe "first-event SSE classification" do
+    test "retries model_not_found before downstream-visible output", %{context: context} do
+      data = terminal_sse("model_not_found", nil)
+
+      assert {{:retry, %{code: "model_not_found"}}, %{classified?: true, buffer: ""}} =
+               StreamAttempt.classify_first_event(
+                 data,
+                 StreamAttempt.first_event_state(),
+                 context
+               )
+    end
+
+    test "retries provenance-backed invalid_request_error for the model parameter", %{
+      context: context
+    } do
+      data = terminal_sse("invalid_request_error", "model")
+
+      assert {{:retry, %{upstream_error_param: "model"}}, %{classified?: true, buffer: ""}} =
+               StreamAttempt.classify_first_event(
+                 data,
+                 StreamAttempt.first_event_state(),
+                 context
+               )
+    end
+
+    test "writes ambiguous model errors when provenance is absent", %{context: context} do
+      context =
+        selected_context(context.assignment.id,
+          source_assignment_ids: [Ecto.UUID.generate()]
+        )
+
+      data = terminal_sse("invalid_request_error", "model")
+
+      assert {{:write_terminal_failure, ^data, %{code: "invalid_request_error"}},
+              %{classified?: true, buffer: ""}} =
+               StreamAttempt.classify_first_event(
+                 data,
+                 StreamAttempt.first_event_state(),
+                 context
+               )
+    end
+  end
+
+  defp selected_context(assignment_id, opts) do
+    request_options = RequestOptions.build(%{}, @endpoint, %{"model" => "synthetic-model"})
+
+    %SelectedCandidateContext{
+      assignment: %PoolUpstreamAssignment{id: assignment_id},
+      model: %Model{
+        exposed_model_id: "synthetic-model",
+        metadata: %{"source_assignment_ids" => Keyword.fetch!(opts, :source_assignment_ids)}
+      },
+      endpoint: @endpoint,
+      request_options: request_options,
+      allow_retry?: true
+    }
+  end
+
+  defp model_not_found_failure do
+    %{
+      code: "model_not_found",
+      upstream_code: "model_not_found",
+      upstream_error_param: nil
+    }
+  end
+
+  defp invalid_request_model_failure do
+    %{
+      code: "invalid_request_error",
+      upstream_code: "invalid_request_error",
+      upstream_error_param: "model"
+    }
+  end
+
+  defp terminal_sse(code, param) do
+    error = %{"code" => code} |> maybe_put("param", param)
+
+    "event: response.failed\n" <>
+      "data: #{Jason.encode!(%{"type" => "response.failed", "response" => %{"error" => error}})}\n\n"
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+end

--- a/test/codex_pooler_web/controllers/runtime/backend_codex_controller_test.exs
+++ b/test/codex_pooler_web/controllers/runtime/backend_codex_controller_test.exs
@@ -4877,6 +4877,86 @@ defmodule CodexPoolerWeb.Runtime.BackendCodexControllerTest do
     assert second_request.request_metadata["routing"]["bridge_ring_size"] == 2
   end
 
+  @tag :feature_model_unavailable_failover
+  test "POST /backend-api/codex/responses fails over when a catalog source lacks the model",
+       %{conn: conn} do
+    unavailable_upstream =
+      start_upstream(
+        FakeUpstream.json_response(
+          %{
+            "error" => %{
+              "code" => "model_not_found",
+              "message" => "model is not installed on this account",
+              "type" => "invalid_request_error"
+            }
+          },
+          404
+        )
+      )
+
+    success_upstream =
+      start_upstream(
+        FakeUpstream.json_response(%{
+          "id" => "resp_model_unavailable_http_fallback",
+          "object" => "response",
+          "usage" => %{"input_tokens" => 4, "output_tokens" => 3, "total_tokens" => 7}
+        })
+      )
+
+    setup = gateway_setup(unavailable_upstream)
+
+    fallback =
+      gateway_upstream(setup.pool, success_upstream, "upstream-token-model-fallback",
+        compact?: false
+      )
+
+    prime_routing_quota!(fallback.identity)
+    use_routing_strategy!(setup.pool, "bridge_ring", 2)
+
+    setup =
+      Map.put(
+        setup,
+        :model,
+        put_model_source_assignments!(setup.model, [setup.assignment, fallback.assignment])
+      )
+
+    request_id = seed_with_assignment_order([setup.assignment.id, fallback.assignment.id])
+
+    conn =
+      conn
+      |> put_req_header("x-request-id", request_id)
+      |> auth(setup)
+      |> post("/backend-api/codex/responses", %{
+        "model" => setup.model.exposed_model_id,
+        "input" => "model unavailable HTTP fallback"
+      })
+
+    assert %{"id" => "resp_model_unavailable_http_fallback"} = json_response(conn, 200)
+    assert FakeUpstream.count(unavailable_upstream) == 1
+    assert FakeUpstream.count(success_upstream) == 1
+
+    assert [first_attempt, second_attempt] =
+             Repo.all(from(a in Attempt, order_by: [asc: a.attempt_number]))
+
+    assert first_attempt.pool_upstream_assignment_id == setup.assignment.id
+    assert first_attempt.status == "retryable_failed"
+    assert first_attempt.retryable == true
+    assert first_attempt.upstream_status_code == 404
+    assert first_attempt.network_error_code == "model_unavailable"
+    assert second_attempt.pool_upstream_assignment_id == fallback.assignment.id
+    assert second_attempt.status == "succeeded"
+
+    assert [request] = Repo.all(from(r in Request, where: r.pool_id == ^setup.pool.id))
+    assert request.status == "succeeded"
+    assert request.transport == "http_json"
+    assert request.retry_count == 1
+    assert request.last_error_code == nil
+
+    metadata_text = inspect({request.request_metadata, first_attempt.response_metadata})
+    refute metadata_text =~ "model is not installed on this account"
+    refute metadata_text =~ "upstream-token-model-fallback"
+  end
+
   test "POST /backend-api/codex/responses bridge_ring retries only within the default shortlist",
        %{
          conn: conn
@@ -5845,6 +5925,24 @@ defmodule CodexPoolerWeb.Runtime.BackendCodexControllerTest do
       refute Map.has_key?(failed_attempt.response_metadata, "upstream_error_param")
       refute Map.has_key?(successful_attempt.response_metadata, "upstream_error_param")
     end
+  end
+
+  @tag :feature_model_unavailable_failover
+  test "SSE first-event model_not_found fails over to the next catalog source" do
+    {setup, unavailable_upstream, success_upstream} =
+      stream_retry_setup(first_event_terminal_sse("response.failed", "model_not_found"))
+
+    execute_backend_stream!(setup, "first-event-model-unavailable-retry")
+
+    assert FakeUpstream.count(unavailable_upstream) == 1
+    assert FakeUpstream.count(success_upstream) == 1
+    assert_stream_retry_success!(setup, "model_not_found")
+
+    assert [first_attempt, second_attempt] =
+             Repo.all(from(a in Attempt, order_by: [asc: a.attempt_number]))
+
+    assert first_attempt.pool_upstream_assignment_id == setup.assignment.id
+    assert second_attempt.pool_upstream_assignment_id == setup.fallback_assignment.id
   end
 
   @tag :task_4_first_event_stream_retry

--- a/test/codex_pooler_web/controllers/runtime/backend_codex_websocket_test.exs
+++ b/test/codex_pooler_web/controllers/runtime/backend_codex_websocket_test.exs
@@ -6259,6 +6259,104 @@ defmodule CodexPoolerWeb.Runtime.BackendCodexWebsocketTest do
     refute metadata_text =~ "upstream-token"
   end
 
+  @tag :feature_model_unavailable_failover
+  test "websocket model_not_found first event fails over to the next catalog source" do
+    unavailable_upstream =
+      start_upstream(
+        FakeUpstream.sse_stream(
+          [
+            {"error",
+             %{
+               "type" => "error",
+               "status" => 404,
+               "code" => "model_not_found",
+               "param" => "model",
+               "message" => "model is not installed on this account"
+             }}
+          ],
+          done: false
+        )
+      )
+
+    fallback_upstream =
+      start_upstream(
+        FakeUpstream.json_response(%{
+          "id" => "resp_ws_model_unavailable_fallback",
+          "object" => "response",
+          "usage" => %{"input_tokens" => 4, "output_tokens" => 3, "total_tokens" => 7}
+        })
+      )
+
+    setup = gateway_setup(unavailable_upstream)
+
+    fallback =
+      gateway_upstream(setup.pool, fallback_upstream, "upstream-token-ws-model-fallback",
+        compact?: false
+      )
+
+    prime_routing_quota!(fallback.identity)
+    use_routing_strategy!(setup.pool, "bridge_ring", 2)
+
+    setup =
+      Map.put(
+        setup,
+        :model,
+        put_model_source_assignments!(setup.model, [setup.assignment, fallback.assignment])
+      )
+
+    request_id =
+      seed_preferring_assignment(
+        [setup.assignment.id, fallback.assignment.id],
+        setup.assignment.id
+      )
+
+    {:ok, auth} = Access.authenticate_authorization_header(setup.authorization)
+
+    assert :ok =
+             execute_websocket_response(
+               auth,
+               Jason.encode!(%{
+                 "type" => "response.create",
+                 "model" => setup.model.exposed_model_id,
+                 "input" => "fail over unavailable websocket model",
+                 "stream" => true,
+                 "generate" => true
+               }),
+               %{request_id: request_id},
+               fn frame -> send(self(), {:websocket_frame, frame}) end
+             )
+
+    assert_received {:websocket_frame, frame}
+    assert %{"id" => "resp_ws_model_unavailable_fallback"} = Jason.decode!(frame)
+    refute_received {:websocket_frame, _unexpected}
+
+    assert FakeUpstream.count(unavailable_upstream) == 1
+    assert FakeUpstream.count(fallback_upstream) == 1
+
+    assert [first_attempt, second_attempt] =
+             Repo.all(from(a in Attempt, order_by: [asc: a.attempt_number]))
+
+    assert first_attempt.pool_upstream_assignment_id == setup.assignment.id
+    assert first_attempt.status == "retryable_failed"
+    assert first_attempt.retryable == true
+    assert first_attempt.network_error_code == "model_not_found"
+    assert first_attempt.response_metadata["stream_failure_stage"] == "first_event"
+    assert first_attempt.response_metadata["stream_error_code"] == "model_not_found"
+    assert first_attempt.response_metadata["upstream_error_param"] == "model"
+
+    assert second_attempt.pool_upstream_assignment_id == fallback.assignment.id
+    assert second_attempt.status == "succeeded"
+
+    assert [request] = Repo.all(from(r in Request, where: r.pool_id == ^setup.pool.id))
+    assert request.status == "succeeded"
+    assert request.retry_count == 1
+    assert request.last_error_code == nil
+
+    metadata_text = inspect({request.request_metadata, first_attempt.response_metadata})
+    refute metadata_text =~ "model is not installed on this account"
+    refute metadata_text =~ "upstream-token-ws-model-fallback"
+  end
+
   @tag :feature_websocket_connection_limit_retry
   test "websocket connection limit first event retries same assignment without demotion" do
     upstream =


### PR DESCRIPTION
## Summary

- Fail over to the next planned upstream assignment when the selected assignment explicitly reports model_not_found.
- Recognize provenance-backed invalid_request_error responses for param=model as an ambiguous model-availability signal.
- Apply the same classification and policy to non-stream HTTP, first-event SSE, and pre-visible WebSocket responses.
- Keep compact requests, hard-pinned continuity, exhausted route plans, unproven ambiguous errors, and post-visible stream failures terminal.
- Preserve existing same-assignment WebSocket retry behavior for connection limits and transport closes.

## Problem

Catalog synchronization describes which assignments advertise each model, but that catalog can become stale between discovery and dispatch. An assignment can remain in the route plan and then return an explicit model-not-found response. Before this change:

- non-stream HTTP finalized the first 400/404 response;
- SSE forwarded a first-event response.failed/error terminal event;
- WebSocket finalized or forwarded the first terminal frame.

A healthy second catalog source was never attempted, even though normal 5xx and network paths already supported candidate failover.

Treating every invalid request as retryable would be unsafe. It could replay malformed client requests across accounts, break continuity, or hide a real validation error. The implementation therefore centralizes a narrow signal classifier and a separate failover policy.

## Shared classification

CodexPooler.Gateway.Runtime.ModelUnavailable is the single classifier used by all three routes.

Explicit signal:

- code or upstream_code is model_not_found;
- accepted without the ambiguous provenance rule because the upstream named model availability directly.

Ambiguous signal:

- invalid_request_error;
- parameter is exactly model;
- for HTTP, status is exactly 404;
- the selected assignment ID appears in the model catalog metadata source_assignment_ids.

The provenance check matters because an unproven generic invalid-request response must remain terminal. Conflicting explicit error codes are not reclassified merely because type=invalid_request_error and param=model.

The classifier accepts the sanitized upstream_error_param already produced by StreamProtocol. It does not inspect or persist raw error messages.

## Failover policy

A recognized model-availability signal is retryable only when all of these conditions hold:

- the selected candidate context says another planned candidate is available;
- the endpoint is not /backend-api/codex/responses/compact;
- SessionContinuity reports no hard pin.

Hard pins include continuity that cannot safely move assignments, such as previous-response, file-affinity, and live upstream-WebSocket ownership. Soft routing affinity remains eligible for normal failover.

For SSE and WebSocket, classification is considered only before downstream-visible output. Once output starts, the existing terminal/partial-stream behavior remains unchanged.

## HTTP path

For non-2xx responses below the existing 429/5xx branch:

1. enforce the existing bounded-response-body checks;
2. record rate-limit/error observations;
3. classify the sanitized JSON error;
4. record a model_unavailable route failure;
5. settle the first attempt as retryable_failed with network_error_code=model_unavailable;
6. return the existing retry tuple so CandidateDispatch selects the next route-plan entry.

When policy blocks failover or no candidate remains, the response is finalized through the existing upstream-status path and returned without replay.

## SSE path

StreamDispatch now passes the selected candidate context into first-event classification. StreamAttempt preserves the existing transient-code classifier, then evaluates model availability only for a complete first terminal event.

A permitted signal returns the existing retry-first-event result, so StreamLifecycle:

- records the first attempt and sanitized stream metadata;
- records route health;
- resets downstream stream state;
- dispatches from the next candidate index.

Ambiguous errors without provenance are written downstream and finalized as before.

## WebSocket path

UpstreamWebsocketSession recognizes a model-availability signature only while downstream_output_started? is false and returns a distinct model_unavailable_first_event reason.

WebsocketAttempt then applies catalog provenance and the shared policy:

- permitted failures are settled and dispatched through CandidateDispatch from the next candidate index;
- this is intentionally different from websocket_connection_limit_reached, which continues to retry the same assignment;
- blocked or exhausted failures deliver the original sanitized WebSocket frame downstream and finalize the attempt;
- the retry-dispatch callback is now carried into WebSocket finalization callbacks for cross-assignment dispatch.

Existing authentication refresh, same-assignment connection-limit retry, owner recovery, and pre-visible transport retry behavior are unchanged.

## Accounting, routing health, and privacy

Successful failover produces two attempts:

- first assignment: retryable_failed, retryable=true, sanitized model/stream error code;
- fallback assignment: succeeded.

The request completes succeeded with retry_count=1 and no terminal last_error_code. Routing health receives the model-availability failure for the stale assignment.

Regression assertions verify that raw upstream error messages and upstream bearer tokens are absent from persisted request/attempt metadata.

## Regression coverage

Shared policy tests cover:

- explicit model_not_found at HTTP 400 and 404;
- provenance-backed ambiguous HTTP 404;
- rejection at HTTP 400, without provenance, with unrelated parameters, with conflicting codes, and with malformed JSON;
- explicit and ambiguous stream failure maps;
- exhausted candidate plans;
- compact endpoints;
- hard-pinned previous-response continuity;
- SSE retry classification and no-provenance terminal classification.

End-to-end runtime tests cover:

- HTTP JSON: first assignment returns 404 model_not_found, second assignment succeeds;
- HTTP SSE: first terminal response.failed reports model_not_found, second assignment completes the stream;
- WebSocket: first pre-visible error frame reports model_not_found, second assignment completes and writes the downstream frame.

They verify assignment IDs, attempt status, retryability, error codes, request completion, retry count, upstream call counts, and metadata redaction.

## Compatibility regression coverage

- StreamAttempt, shared classifier, and upstream WebSocket session suites: 39 passed.
- Existing websocket_connection_limit_reached feature group: 3 passed.
- Model-unavailable HTTP/SSE/WebSocket feature group: 3 passed.
- Combined classifier plus three route cases: 12 passed.

The broader first-event SSE retry tag produced 10 passing cases and one timing-only keepalive assertion. The same keepalive assertion fails on the unmodified current PR base with identical output, so it is a pre-existing baseline issue rather than a change introduced here.

## Quality checks

- mix compile --warnings-as-errors
  - passed
- mix credo --strict on all ten changed source/test files
  - no issues
- git diff --check
  - passed

## Scope

This PR contains only model-unavailable classification, transport failover wiring, and directly related tests. Terminal lifecycle fencing is separate in #158. Atomic rollups and API-key uniqueness are separate in #159. No catalog-sync, stale-refresh recovery, assignment activation, admin UI, configuration, or deployment changes are included.

## Deployment notes

No database migration or configuration change is required. This PR has not been deployed and does not modify Portainer.