### PR TITLE
fix(catalog): preserve partial upstream sync results

### DIFF
--- a/lib/codex_pooler/catalog/sync.ex
+++ b/lib/codex_pooler/catalog/sync.ex
@@ -161,8 +161,11 @@ defmodule CodexPooler.Catalog.Sync do
 
   defp discover_and_persist_catalog(run, assignments, fetcher) do
     case Discovery.discover_models(assignments, fetcher) do
-      {:ok, discovered} -> Persistence.persist_catalog(run, assignments, discovered)
-      {:error, reason} -> Persistence.fail_sync_run(run, reason)
+      {:ok, successful_assignments, discovered} ->
+        Persistence.persist_catalog(run, assignments, successful_assignments, discovered)
+
+      {:error, reason} ->
+        Persistence.fail_sync_run(run, reason)
     end
   end
 

--- a/lib/codex_pooler/catalog/sync/discovery.ex
+++ b/lib/codex_pooler/catalog/sync/discovery.ex
@@ -14,19 +14,35 @@ defmodule CodexPooler.Catalog.Sync.Discovery do
   @type catalog_error :: %{required(:code) => atom(), required(:message) => String.t()}
 
   @spec discover_models([map()], (map() -> {:ok, [map()]} | {:error, term()})) ::
-          {:ok, [map()]} | {:error, term()}
+          {:ok, [map()], [map()]} | {:error, term()}
   def discover_models(assignments, fetcher) do
-    Enum.reduce_while(assignments, {:ok, []}, fn source, {:ok, discovered} ->
-      case fetcher.(source) do
-        {:ok, models} when is_list(models) ->
-          source_models = Enum.map(models, &Map.put(normalize_model_attrs(&1), :source, source))
-          {:cont, {:ok, discovered ++ source_models}}
+    results =
+      Enum.map(assignments, fn source ->
+        case fetcher.(source) do
+          {:ok, models} when is_list(models) ->
+            source_models = Enum.map(models, &Map.put(normalize_model_attrs(&1), :source, source))
+            {:ok, source, source_models}
 
-        {:error, reason} ->
-          {:halt, {:error, reason}}
-      end
-    end)
+          {:error, reason} ->
+            {:error, reason}
+        end
+      end)
+
+    successes = Enum.filter(results, &match?({:ok, _source, _models}, &1))
+
+    case successes do
+      [] ->
+        all_failed_result(results)
+
+      _successful_results ->
+        successful_assignments = Enum.map(successes, &elem(&1, 1))
+        discovered_models = Enum.flat_map(successes, &elem(&1, 2))
+        {:ok, successful_assignments, discovered_models}
+    end
   end
+
+  defp all_failed_result([]), do: {:ok, [], []}
+  defp all_failed_result([{:error, reason} | _rest]), do: {:error, reason}
 
   @spec fetch_models_for_assignment(map()) :: {:ok, [map()]} | {:error, catalog_error() | term()}
   def fetch_models_for_assignment(%{assignment: assignment, identity: identity}) do

--- a/lib/codex_pooler/catalog/sync/persistence.ex
+++ b/lib/codex_pooler/catalog/sync/persistence.ex
@@ -17,11 +17,20 @@ defmodule CodexPooler.Catalog.Sync.Persistence do
   @succeeded "succeeded"
   @suppressed "suppressed"
 
-  @spec persist_catalog(SyncRun.t(), [map()], [map()]) :: {:ok, map()} | {:error, term()}
-  def persist_catalog(%SyncRun{} = run, assignments, discovered) do
+  @spec persist_catalog(SyncRun.t(), [map()], [map()], [map()]) ::
+          {:ok, map()} | {:error, term()}
+  def persist_catalog(%SyncRun{} = run, assignments, successful_assignments, discovered) do
     timestamp = now()
     grouped = aggregate_models(discovered)
     seen_exposed_ids = Map.keys(grouped)
+    successful_assignment_ids = Enum.map(successful_assignments, & &1.assignment.id)
+
+    failed_assignment_ids =
+      assignments
+      |> Enum.map(& &1.assignment.id)
+      |> Enum.reject(&(&1 in successful_assignment_ids))
+
+    partial? = failed_assignment_ids != []
 
     Multi.new()
     |> then(fn multi ->
@@ -29,17 +38,30 @@ defmodule CodexPooler.Catalog.Sync.Persistence do
         # Reason: per-model Multi step preserves aggregate-specific rollback context.
         # credo:disable-for-next-line Credo.Check.Refactor.Nesting
         Multi.run(multi, {:model, aggregate.exposed_model_id}, fn repo, _changes ->
-          upsert_model(repo, run, aggregate, assignments, timestamp)
+          upsert_model(
+            repo,
+            run,
+            aggregate,
+            assignments,
+            successful_assignments,
+            timestamp
+          )
         end)
       end)
     end)
     |> Multi.run(:stale_marked_count, fn repo, _changes ->
-      mark_missing_models_stale(repo, run, seen_exposed_ids, timestamp)
+      mark_missing_models_stale(
+        repo,
+        run,
+        seen_exposed_ids,
+        failed_assignment_ids,
+        timestamp
+      )
     end)
     |> Multi.update_all(
       :assignment_sync_timestamps,
       from(assignment in PoolUpstreamAssignment,
-        where: assignment.id in ^Enum.map(assignments, & &1.assignment.id)
+        where: assignment.id in ^Enum.map(successful_assignments, & &1.assignment.id)
       ),
       set: [last_successful_sync_at: timestamp, updated_at: timestamp]
     )
@@ -55,7 +77,11 @@ defmodule CodexPooler.Catalog.Sync.Persistence do
         upserted_model_count: upserted_count,
         stale_marked_count: stale_marked_count,
         retired_count: 0,
-        stats: %{"source_assignment_count" => length(assignments)}
+        stats: %{
+          "source_assignment_count" => length(assignments),
+          "successful_source_assignment_count" => length(successful_assignments),
+          "failed_source_assignment_count" => length(assignments) - length(successful_assignments)
+        }
       })
       |> repo.update()
     end)
@@ -67,7 +93,7 @@ defmodule CodexPooler.Catalog.Sync.Persistence do
           |> Map.values()
           |> Enum.filter(&match?(%Model{}, &1))
 
-        {:ok, %{sync_run: changes.sync_run, models: models}}
+        {:ok, %{sync_run: changes.sync_run, models: models, partial?: partial?}}
 
       {:error, _operation, reason, _changes} ->
         fail_sync_run(run, reason)
@@ -93,9 +119,24 @@ defmodule CodexPooler.Catalog.Sync.Persistence do
     end
   end
 
-  defp upsert_model(repo, run, aggregate, assignments, timestamp) do
+  defp upsert_model(
+         repo,
+         run,
+         aggregate,
+         assignments,
+         successful_assignments,
+         timestamp
+       ) do
     existing = get_model_by_exposed_id(run.pool_id, aggregate.exposed_model_id)
-    source_assignments = PreservedSources.assignment_attrs(existing, aggregate, assignments, run)
+
+    source_assignments =
+      PreservedSources.assignment_attrs(
+        existing,
+        aggregate,
+        assignments,
+        successful_assignments,
+        run
+      )
 
     attrs = %{
       pool_id: run.pool_id,
@@ -134,7 +175,13 @@ defmodule CodexPooler.Catalog.Sync.Persistence do
     |> repo.insert_or_update()
   end
 
-  defp mark_missing_models_stale(repo, run, seen_exposed_ids, timestamp) do
+  defp mark_missing_models_stale(
+         repo,
+         run,
+         seen_exposed_ids,
+         failed_assignment_ids,
+         timestamp
+       ) do
     lower_seen = Enum.map(seen_exposed_ids, &String.downcase/1)
 
     query =
@@ -146,7 +193,12 @@ defmodule CodexPooler.Catalog.Sync.Persistence do
               "coalesce(?->>'manual_smoke_provisioned', 'false') != 'true'",
               model.metadata
             ) and
-            fragment("lower(?)", model.exposed_model_id) not in ^lower_seen
+            fragment("lower(?)", model.exposed_model_id) not in ^lower_seen and
+            fragment(
+              "NOT (COALESCE(?->'source_assignment_ids', '[]'::jsonb) \\?| ?)",
+              model.metadata,
+              type(^failed_assignment_ids, {:array, :string})
+            )
 
     {count, _rows} =
       repo.update_all(query,

--- a/lib/codex_pooler/catalog/sync/preserved_sources.ex
+++ b/lib/codex_pooler/catalog/sync/preserved_sources.ex
@@ -18,11 +18,24 @@ defmodule CodexPooler.Catalog.Sync.PreservedSources do
   @spec missing_sync_metadata_key() :: String.t()
   def missing_sync_metadata_key, do: @missing_source_assignment_syncs
 
-  @spec assignment_attrs(Model.t() | nil, aggregate(), [assignment_ref()], SyncRun.t()) :: attrs()
-  def assignment_attrs(existing, aggregate, assignments, %SyncRun{} = run) do
+  @spec assignment_attrs(
+          Model.t() | nil,
+          aggregate(),
+          [assignment_ref()],
+          [assignment_ref()],
+          SyncRun.t()
+        ) :: attrs()
+  def assignment_attrs(
+        existing,
+        aggregate,
+        assignments,
+        successful_assignments,
+        %SyncRun{} = run
+      ) do
     observed_models = normalize_source_assignment_models(aggregate.source_assignment_models)
     observed_ids = observed_models |> Map.keys() |> MapSet.new()
     eligible_ids = assignments |> Enum.map(& &1.assignment.id) |> MapSet.new()
+    successful_ids = successful_assignments |> Enum.map(& &1.assignment.id) |> MapSet.new()
     previous_ids = existing_source_assignment_ids(existing)
     previous_models = existing_source_assignment_models(existing)
     previously_missing = existing_missing_source_assignment_syncs(existing)
@@ -31,7 +44,8 @@ defmodule CodexPooler.Catalog.Sync.PreservedSources do
       Enum.filter(previous_ids, fn assignment_id ->
         MapSet.member?(eligible_ids, assignment_id) and
           not MapSet.member?(observed_ids, assignment_id) and
-          not Map.has_key?(previously_missing, assignment_id)
+          (not MapSet.member?(successful_ids, assignment_id) or
+             not Map.has_key?(previously_missing, assignment_id))
       end)
 
     preserved_models =
@@ -43,7 +57,18 @@ defmodule CodexPooler.Catalog.Sync.PreservedSources do
     source_assignment_ids = source_assignment_models |> Map.keys() |> Enum.sort()
 
     missing_source_assignment_syncs =
-      Map.new(preserved_ids, fn assignment_id -> {assignment_id, run.id} end)
+      Enum.reduce(preserved_ids, %{}, fn assignment_id, markers ->
+        cond do
+          MapSet.member?(successful_ids, assignment_id) ->
+            Map.put(markers, assignment_id, run.id)
+
+          Map.has_key?(previously_missing, assignment_id) ->
+            Map.put(markers, assignment_id, Map.fetch!(previously_missing, assignment_id))
+
+          true ->
+            markers
+        end
+      end)
 
     %{
       source_assignment_ids: source_assignment_ids,

--- a/test/codex_pooler/catalog_test.exs
+++ b/test/codex_pooler/catalog_test.exs
@@ -430,6 +430,120 @@ defmodule CodexPooler.CatalogTest do
       assert masterkain_only.metadata["source_assignment_ids"] == [masterkain_assignment.id]
     end
 
+    test "persists successful assignment results when another assignment fails" do
+      pool = pool_fixture()
+
+      {_pool, successful_assignment} =
+        active_assignment_fixture(pool, %{}, %{
+          account_label: "Successful catalog source",
+          assignment_label: "Successful assignment"
+        })
+
+      {_pool, failed_assignment} =
+        active_assignment_fixture(pool, %{}, %{
+          account_label: "Failed catalog source",
+          assignment_label: "Failed assignment"
+        })
+
+      failed_only =
+        model_fixture(pool, %{
+          exposed_model_id: "gpt-failed-only",
+          metadata: %{
+            "source_assignment_ids" => [failed_assignment.id],
+            "source_assignment_models" => %{
+              failed_assignment.id => %{"source_marker" => "failed-existing"}
+            }
+          }
+        })
+
+      successful_only_removed =
+        model_fixture(pool, %{
+          exposed_model_id: "gpt-success-removed",
+          metadata: %{
+            "source_assignment_ids" => [successful_assignment.id],
+            "source_assignment_models" => %{
+              successful_assignment.id => %{"source_marker" => "successful-removed"}
+            }
+          }
+        })
+
+      model_fixture(pool, %{
+        exposed_model_id: "gpt-partial-shared",
+        source_assignment_count: 2,
+        metadata: %{
+          "source_assignment_ids" => Enum.sort([successful_assignment.id, failed_assignment.id]),
+          "source_assignment_models" => %{
+            successful_assignment.id => %{"source_marker" => "successful-existing"},
+            failed_assignment.id => %{"source_marker" => "failed-existing"}
+          }
+        }
+      })
+
+      successful_assignment_id = successful_assignment.id
+      failed_assignment_id = failed_assignment.id
+
+      fetcher = fn %{assignment: assignment} ->
+        case assignment.id do
+          ^successful_assignment_id ->
+            {:ok,
+             [
+               %{"id" => "gpt-success-only"},
+               %{"id" => "gpt-partial-shared", "source_marker" => "successful-current"}
+             ]}
+
+          ^failed_assignment_id ->
+            {:error, %{message: "upstream assignment unavailable"}}
+        end
+      end
+
+      assert {:ok, %{models: models, sync_run: sync_run, partial?: true}} =
+               Catalog.sync_pool_catalog(pool, fetcher: fetcher)
+
+      assert Enum.sort(Enum.map(models, & &1.exposed_model_id)) == [
+               "gpt-partial-shared",
+               "gpt-success-only"
+             ]
+
+      assert sync_run.status == "succeeded"
+      assert sync_run.stale_marked_count == 1
+
+      assert sync_run.stats == %{
+               "source_assignment_count" => 2,
+               "successful_source_assignment_count" => 1,
+               "failed_source_assignment_count" => 1
+             }
+
+      assert %DateTime{} = Repo.reload!(successful_assignment).last_successful_sync_at
+      assert is_nil(Repo.reload!(failed_assignment).last_successful_sync_at)
+
+      persisted_failed_only = Repo.reload!(failed_only)
+      assert persisted_failed_only.status == "active"
+      assert persisted_failed_only.last_sync_run_id == failed_only.last_sync_run_id
+      assert persisted_failed_only.last_seen_at == failed_only.last_seen_at
+
+      persisted_successful_only_removed = Repo.reload!(successful_only_removed)
+      assert persisted_successful_only_removed.status == "stale"
+      assert persisted_successful_only_removed.last_sync_run_id == sync_run.id
+
+      assert {:ok, %{partial?: true}} = Catalog.sync_pool_catalog(pool, fetcher: fetcher)
+
+      shared = Catalog.get_model_by_exposed_id(pool, "gpt-partial-shared")
+      assert shared.source_assignment_count == 2
+
+      assert shared.metadata["source_assignment_ids"] ==
+               Enum.sort([successful_assignment.id, failed_assignment.id])
+
+      assert shared.metadata["source_assignment_models"][successful_assignment.id][
+               "source_marker"
+             ] == "successful-current"
+
+      assert shared.metadata["source_assignment_models"][failed_assignment.id]["source_marker"] ==
+               "failed-existing"
+
+      assert shared.metadata["source_assignment_missing_sync_run_ids"] == %{}
+      assert Repo.reload!(failed_only).status == "active"
+    end
+
     test "preserves an active absent source for one successful sync before retiring it" do
       pool = pool_fixture()
 


### PR DESCRIPTION
## Summary

- continue catalog discovery when one upstream assignment fails, while preserving the existing all-failed error behavior
- persist successful assignment results without aging out models or source metadata owned by failed assignments
- stale confirmed removals from successfully queried sources and advance success timestamps only for those assignments
- record successful and failed assignment counts on the catalog sync run

## Testing

- `mix test test/codex_pooler/catalog_test.exs` (21 passed after rebasing onto current `main`)
- `mix test test/codex_pooler/catalog_test.exs test/codex_pooler/jobs_test.exs test/codex_pooler/jobs/reconciliation_jobs_test.exs test/codex_pooler/admin/pool_workflow_test.exs` (122 passed)
- `mix compile --warnings-as-errors --force`
- `mix credo --strict`
- `git diff --check`