### PR TITLE
fix(upstreams): recover stale refreshing identities

### DIFF
--- a/lib/codex_pooler/jobs/token_refresh_recovery.ex
+++ b/lib/codex_pooler/jobs/token_refresh_recovery.ex
@@ -11,8 +11,9 @@ defmodule CodexPooler.Jobs.TokenRefreshRecovery do
   alias CodexPooler.Upstreams.Schemas.{PoolUpstreamAssignment, UpstreamIdentity}
 
   @refresh_due UpstreamIdentity.refresh_due_status()
+  @refreshing UpstreamIdentity.refreshing_status()
   @refresh_failed UpstreamIdentity.refresh_failed_status()
-  @candidate_statuses [@refresh_due, @refresh_failed]
+  @candidate_statuses [@refresh_due, @refreshing, @refresh_failed]
   @assignment_active PoolUpstreamAssignment.active_status()
   @pool_active "active"
   @incomplete_job_states ~w(available scheduled executing retryable)
@@ -86,6 +87,20 @@ defmodule CodexPooler.Jobs.TokenRefreshRecovery do
     end
   end
 
+  defp with_eligibility_timestamp(
+         %UpstreamIdentity{status: status} = identity,
+         now
+       )
+       when status == @refreshing do
+    reference_at =
+      identity.metadata
+      |> token_refresh_metadata()
+      |> started_at()
+      |> Kernel.||(timestamp_or_now(identity.updated_at || identity.created_at, now))
+
+    [{identity, reference_at}]
+  end
+
   defp fresh_token_refresh_in_progress?(%UpstreamIdentity{} = identity, now) do
     identity.metadata
     |> token_refresh_metadata()
@@ -111,6 +126,19 @@ defmodule CodexPooler.Jobs.TokenRefreshRecovery do
     case metadata["finished_at"] do
       finished_at when is_binary(finished_at) ->
         case DateTime.from_iso8601(finished_at) do
+          {:ok, parsed, _offset} -> DateTime.truncate(parsed, :microsecond)
+          _invalid -> nil
+        end
+
+      _value ->
+        nil
+    end
+  end
+
+  defp started_at(%{} = metadata) do
+    case metadata["started_at"] do
+      started_at when is_binary(started_at) ->
+        case DateTime.from_iso8601(started_at) do
           {:ok, parsed, _offset} -> DateTime.truncate(parsed, :microsecond)
           _invalid -> nil
         end

--- a/test/codex_pooler/jobs/token_refresh_recovery_test.exs
+++ b/test/codex_pooler/jobs/token_refresh_recovery_test.exs
@@ -43,7 +43,7 @@ defmodule CodexPooler.Jobs.TokenRefreshRecoveryTest do
       assert [] = all_enqueued(worker: TokenRefreshWorker)
     end
 
-    test "only refresh_due and cooled-down refresh_failed identities are scheduled candidates" do
+    test "only recoverable lifecycle states are scheduled candidates" do
       due = recovery_identity_fixture("refresh_due", updated_at: DateTime.add(@now, -15, :minute))
 
       failed =
@@ -60,7 +60,6 @@ defmodule CodexPooler.Jobs.TokenRefreshRecoveryTest do
 
       for status <- [
             "active",
-            "refreshing",
             "reauth_required",
             "paused",
             "deleted",
@@ -147,17 +146,17 @@ defmodule CodexPooler.Jobs.TokenRefreshRecoveryTest do
     end
 
     test "fresh in-progress token refresh metadata blocks recovery, but stale or malformed metadata does not" do
-      recovery_identity_fixture("refresh_due",
+      recovery_identity_fixture("refreshing",
         metadata: refreshing_metadata(DateTime.add(@now, -10, :second), 60_000)
       )
 
       stale =
-        recovery_identity_fixture("refresh_due",
+        recovery_identity_fixture("refreshing",
           metadata: refreshing_metadata(DateTime.add(@now, -2, :minute), 60_000)
         )
 
       malformed =
-        recovery_identity_fixture("refresh_due",
+        recovery_identity_fixture("refreshing",
           metadata: %{
             "token_refresh" => %{
               "status" => "refreshing",


### PR DESCRIPTION
## Summary

Scheduled token-refresh recovery can now reclaim upstream identities left in the `refreshing` lifecycle state after an interrupted or orphaned refresh attempt.

## Why this was needed

The token-refresh implementation already supports taking over a stale `refreshing` attempt under a database row lock. The scheduled recovery selector, however, only queried `refresh_due` and `refresh_failed` identities. If a process died after claiming an identity but before finalizing it, that identity could remain `refreshing` indefinitely and would never reach the worker code that knows how to recover it.

## Behavior

- Includes `refreshing` identities in scheduled recovery candidate selection.
- Continues to exclude a valid in-progress attempt while its `stale_after_ms` lease is fresh.
- Treats stale or malformed refresh-attempt metadata as recoverable instead of leaving the identity stranded.
- Orders recovered `refreshing` candidates by their recorded `started_at`; falls back to the identity timestamp when the metadata timestamp is missing or invalid.
- Preserves all existing eligibility boundaries: the identity must have an active assignment in an active Pool, and an incomplete token-refresh Oban job still suppresses duplicate enqueueing.

## Safety and scope

- No migration or data rewrite is required.
- No credential/token material is added to job arguments or logs.
- The worker's existing row-locked stale-attempt takeover remains the final concurrency guard.
- This PR is limited to the recovery selector and its tests; catalog sync, Pool assignment UI/lifecycle changes, and unrelated refresh controls are intentionally excluded.

## Validation

- `mix test test/codex_pooler/jobs/token_refresh_recovery_test.exs` - 10 passed, 0 failures
- `mix compile --warnings-as-errors --force` - passed (653 files compiled)
- `mix credo --strict` - passed (931 files, no issues)
- `git diff --check` - passed