### PR TITLE
fix(jobs): dedupe automatic reconciliation by upstream identity

### DIFF
--- a/lib/codex_pooler/gateway/runtime/finalization/side_effects.ex
+++ b/lib/codex_pooler/gateway/runtime/finalization/side_effects.ex
@@ -81,16 +81,7 @@ defmodule CodexPooler.Gateway.Runtime.Finalization.SideEffects do
 
   @spec maybe_enqueue_gateway_reconciliation(Jobs.pool_ref(), PoolUpstreamAssignment.t()) :: :ok
   def maybe_enqueue_gateway_reconciliation(pool_id, assignment) do
-    result =
-      Jobs.enqueue_account_reconciliation(pool_id, assignment,
-        trigger_kind: "gateway",
-        unique: [
-          fields: [:args, :queue, :worker],
-          keys: [:pool_id, :pool_upstream_assignment_id, :trigger_kind],
-          states: :successful,
-          period: 60
-        ]
-      )
+    result = Jobs.enqueue_gateway_account_reconciliation(pool_id, assignment)
 
     case result do
       {:ok, _job} ->

--- a/lib/codex_pooler/jobs.ex
+++ b/lib/codex_pooler/jobs.ex
@@ -101,6 +101,14 @@ defmodule CodexPooler.Jobs do
     UpstreamEnqueue.enqueue_account_reconciliation(pool_or_id, assignment_or_id, opts)
   end
 
+  @spec enqueue_gateway_account_reconciliation(
+          pool_ref(),
+          PoolUpstreamAssignment.t()
+        ) :: job_insert_result()
+  def enqueue_gateway_account_reconciliation(pool_or_id, %PoolUpstreamAssignment{} = assignment) do
+    UpstreamEnqueue.enqueue_gateway_account_reconciliation(pool_or_id, assignment)
+  end
+
   @spec enqueue_assignment_priming(pool_ref(), assignment_ref(), keyword()) ::
           job_insert_result() | {:error, term()}
   def enqueue_assignment_priming(pool_or_id, assignment_or_id, opts \\ []) do

--- a/lib/codex_pooler/jobs/upstream_enqueue.ex
+++ b/lib/codex_pooler/jobs/upstream_enqueue.ex
@@ -1,6 +1,8 @@
 defmodule CodexPooler.Jobs.UpstreamEnqueue do
   @moduledoc false
 
+  import Ecto.Query
+
   alias CodexPooler.Events
 
   alias CodexPooler.Jobs.{
@@ -11,6 +13,7 @@ defmodule CodexPooler.Jobs.UpstreamEnqueue do
   }
 
   alias CodexPooler.Pools.Pool
+  alias CodexPooler.Repo
   alias CodexPooler.Upstreams.Lifecycle.CredentialFencing
   alias CodexPooler.Upstreams.Quota
   alias CodexPooler.Upstreams.Schemas.{PoolUpstreamAssignment, UpstreamIdentity}
@@ -25,6 +28,16 @@ defmodule CodexPooler.Jobs.UpstreamEnqueue do
           | :upstream_identity_id_required
   @type job_insert_result ::
           {:ok, Oban.Job.t()} | {:error, Ecto.Changeset.t() | missing_ref_error()}
+
+  @automatic_reconciliation_unique [
+    fields: [:args, :queue, :worker],
+    keys: [:upstream_identity_id],
+    states: :successful,
+    period: 60
+  ]
+  # Oban applies the period to incomplete states too. Keep a separate incomplete-state
+  # guard so a long-running job never falls out of the short completion cooldown.
+  @incomplete_job_states ~w(suspended available scheduled executing retryable)
 
   @spec enqueue_token_refresh(identity_ref(), keyword()) :: job_insert_result()
   def enqueue_token_refresh(identity_or_id, opts \\ []) do
@@ -76,6 +89,19 @@ defmodule CodexPooler.Jobs.UpstreamEnqueue do
     end
   end
 
+  @spec enqueue_gateway_account_reconciliation(pool_ref(), PoolUpstreamAssignment.t()) ::
+          job_insert_result()
+  def enqueue_gateway_account_reconciliation(
+        pool_or_id,
+        %PoolUpstreamAssignment{} = assignment
+      ) do
+    enqueue_automatic_identity_account_reconciliation(
+      pool_or_id,
+      assignment,
+      trigger_kind: "gateway"
+    )
+  end
+
   @spec enqueue_saved_reset_redemption(assignment_ref(), keyword()) :: job_insert_result()
   def enqueue_saved_reset_redemption(assignment_or_id, opts \\ []) do
     with {:ok, assignment_id} <- assignment_id(assignment_or_id) do
@@ -97,18 +123,100 @@ defmodule CodexPooler.Jobs.UpstreamEnqueue do
         %PoolUpstreamAssignment{} = assignment,
         opts \\ []
       ) do
-    assignment.pool_id
-    |> account_reconciliation_args(assignment.id, opts)
-    |> Map.merge(%{
-      "upstream_identity_id" => assignment.upstream_identity_id,
-      "target_kind" => "upstream_identity"
-    })
-    |> maybe_put_recovery_fence(assignment)
-    |> AccountReconciliationWorker.new(
-      Options.job_options(opts, unique_keys: [:upstream_identity_id, :trigger_kind])
+    enqueue_automatic_identity_account_reconciliation(
+      assignment.pool_id,
+      assignment,
+      Keyword.put_new(opts, :trigger_kind, "scheduled")
     )
-    |> Oban.insert()
-    |> tap_job_status_event(assignment.pool_id, "account_reconciliation", "scheduled")
+  end
+
+  defp enqueue_automatic_identity_account_reconciliation(pool_or_id, assignment, opts) do
+    with {:ok, pool_id} <- pool_id(pool_or_id) do
+      args =
+        pool_id
+        |> account_reconciliation_args(assignment.id, opts)
+        |> Map.merge(%{
+          "upstream_identity_id" => assignment.upstream_identity_id,
+          "target_kind" => "upstream_identity"
+        })
+        |> maybe_put_recovery_fence(assignment)
+
+      args
+      |> insert_automatic_identity_account_reconciliation(assignment, opts)
+      |> tap_job_status_event(pool_id, "account_reconciliation", "scheduled")
+    end
+  end
+
+  defp insert_automatic_identity_account_reconciliation(args, assignment, opts) do
+    transaction_result =
+      Repo.transaction(fn ->
+        # Serialize automatic enqueues across triggers and assignments for this identity.
+        case lock_upstream_identity(assignment.upstream_identity_id) do
+          %UpstreamIdentity{} ->
+            insert_unless_incomplete_reconciliation(args, assignment.upstream_identity_id, opts)
+
+          nil ->
+            {:error, :upstream_identity_id_required}
+        end
+      end)
+
+    case transaction_result do
+      {:ok, result} -> result
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp lock_upstream_identity(identity_id) do
+    Repo.one(
+      from(identity in UpstreamIdentity,
+        where: identity.id == ^identity_id,
+        lock: "FOR UPDATE"
+      )
+    )
+  end
+
+  defp insert_unless_incomplete_reconciliation(args, identity_id, opts) do
+    case incomplete_reconciliation_job(identity_id) do
+      %Oban.Job{} = job ->
+        {:ok, %{job | conflict?: true}}
+
+      nil ->
+        args
+        |> AccountReconciliationWorker.new(automatic_reconciliation_job_options(opts))
+        |> Oban.insert()
+    end
+  end
+
+  defp incomplete_reconciliation_job(identity_id) do
+    worker = Oban.Worker.to_string(AccountReconciliationWorker)
+
+    Oban.Job
+    |> where([job], job.worker == ^worker and job.state in ^@incomplete_job_states)
+    |> where(
+      [job],
+      fragment("?->>'upstream_identity_id' = ?", job.args, ^identity_id) or
+        fragment(
+          """
+          EXISTS (
+            SELECT 1
+            FROM pool_upstream_assignments AS reconciliation_assignment
+            WHERE reconciliation_assignment.id::text = ?->>'pool_upstream_assignment_id'
+              AND reconciliation_assignment.upstream_identity_id::text = ?
+          )
+          """,
+          job.args,
+          ^identity_id
+        )
+    )
+    |> order_by([job], desc: job.inserted_at, desc: job.id)
+    |> limit(1)
+    |> Repo.one()
+  end
+
+  defp automatic_reconciliation_job_options(opts) do
+    opts
+    |> Keyword.take([:scheduled_at, :schedule_in])
+    |> Keyword.put(:unique, @automatic_reconciliation_unique)
   end
 
   defp tap_job_status_event(

--- a/lib/codex_pooler/jobs/workers/upstreams/account_reconciliation_worker.ex
+++ b/lib/codex_pooler/jobs/workers/upstreams/account_reconciliation_worker.ex
@@ -2,8 +2,8 @@ defmodule CodexPooler.Jobs.AccountReconciliationWorker do
   @moduledoc """
   Refreshes one pool assignment's account health, quota windows, and catalog state.
 
-  Scheduled jobs may target an upstream identity for dedupe and operator display while
-  still carrying the canonical assignment used to execute reconciliation.
+  Automatic jobs may target an upstream identity for dedupe and operator display while
+  still carrying the assignment used to execute reconciliation.
   """
 
   use Oban.Worker,

--- a/test/codex_pooler/jobs/reconciliation_jobs_test.exs
+++ b/test/codex_pooler/jobs/reconciliation_jobs_test.exs
@@ -6,6 +6,7 @@ defmodule CodexPooler.Jobs.ReconciliationJobsTest do
   alias CodexPooler.Catalog.SyncRun
   alias CodexPooler.Events
   alias CodexPooler.FakeUpstream
+  alias CodexPooler.Gateway.Runtime.Finalization.SideEffects
   alias CodexPooler.InstanceSettings
   alias CodexPooler.InstanceSettings.Settings
   alias CodexPooler.Jobs
@@ -2192,6 +2193,10 @@ defmodule CodexPooler.Jobs.ReconciliationJobsTest do
           set: [
             state: "completed",
             attempt: 1,
+            inserted_at:
+              DateTime.utc_now()
+              |> DateTime.add(-61, :second)
+              |> DateTime.truncate(:microsecond),
             attempted_at: DateTime.utc_now() |> DateTime.truncate(:microsecond),
             completed_at: DateTime.utc_now() |> DateTime.truncate(:microsecond)
           ]
@@ -2356,75 +2361,209 @@ defmodule CodexPooler.Jobs.ReconciliationJobsTest do
       assert is_nil(assignment.metadata["last_reconciliation"])
     end
 
-    test "gateway-triggered reconciliation deduplicates recently completed jobs" do
+    test "gateway finalization reuses an incomplete scheduled identity reconciliation" do
       {pool, assignment} = active_assignment_fixture(%{})
-      assert :ok = Events.subscribe_pool(pool.id)
+      identity = Upstreams.get_upstream_identity(assignment.upstream_identity_id)
 
-      unique = [
-        fields: [:args, :queue, :worker],
-        keys: [:pool_id, :pool_upstream_assignment_id, :trigger_kind],
-        states: :successful,
-        period: 60
-      ]
-
-      assert {:ok, first_job} =
-               publish_from_task(fn ->
-                 Jobs.enqueue_account_reconciliation(pool, assignment,
-                   trigger_kind: "gateway",
-                   unique: unique
-                 )
-               end)
-
-      assert first_job.args == %{
-               "pool_id" => pool.id,
-               "pool_upstream_assignment_id" => assignment.id,
-               "trigger_kind" => "gateway"
-             }
-
-      first_job_id = Integer.to_string(first_job.id)
-
-      assert_receive {Events,
-                      %{
-                        reason: "job_status_updated",
-                        payload: %{
-                          "id" => ^first_job_id,
-                          "status" => "scheduled",
-                          "worker" => "account_reconciliation"
-                        }
-                      }}
-
-      {1, _rows} =
-        from(job in Oban.Job, where: job.id == ^first_job.id)
-        |> Repo.update_all(
-          set: [
-            state: "completed",
-            attempt: 1,
-            attempted_at: DateTime.utc_now() |> DateTime.truncate(:microsecond),
-            completed_at: DateTime.utc_now() |> DateTime.truncate(:microsecond)
-          ]
+      {_second_pool, second_assignment} =
+        active_assignment_for_identity_fixture(identity,
+          assignment_label: "Gateway assignment duplicate",
+          created_at: DateTime.add(assignment.created_at, 60, :second)
         )
 
-      assert {:ok, second_job} =
-               publish_from_task(fn ->
-                 Jobs.enqueue_account_reconciliation(pool, assignment,
-                   trigger_kind: "gateway",
-                   unique: unique
-                 )
-               end)
+      assert {:ok, %{inserted: [scheduled_job], conflicts: [], errors: []}} =
+               Jobs.enqueue_account_reconciliation_for_active_pools(trigger_kind: "scheduled")
 
-      refute first_job.conflict?
-      assert second_job.conflict?
-      assert second_job.id == first_job.id
-      refute_received {Events, %{reason: "job_status_updated"}}
+      assert :ok =
+               SideEffects.maybe_enqueue_gateway_reconciliation(
+                 second_assignment.pool_id,
+                 second_assignment
+               )
 
-      assert [job] =
+      assert [persisted_job] =
                Repo.all(
                  from(job in Oban.Job,
                    where: job.worker == ^worker_name(AccountReconciliationWorker)
                  )
                )
 
-      assert job.id == first_job.id
+      assert persisted_job.id == scheduled_job.id
+      assert scheduled_job.args["pool_id"] == pool.id
+      assert scheduled_job.args["pool_upstream_assignment_id"] == assignment.id
+      assert scheduled_job.args["upstream_identity_id"] == identity.id
+      assert scheduled_job.args["trigger_kind"] == "scheduled"
+    end
+
+    test "scheduled reconciliation reuses an incomplete gateway identity reconciliation" do
+      {_pool, assignment} = active_assignment_fixture(%{})
+      identity = Upstreams.get_upstream_identity(assignment.upstream_identity_id)
+
+      {second_pool, second_assignment} =
+        active_assignment_for_identity_fixture(identity,
+          assignment_label: "Scheduled assignment duplicate",
+          created_at: DateTime.add(assignment.created_at, 60, :second)
+        )
+
+      assert {:ok, gateway_job} =
+               Jobs.enqueue_gateway_account_reconciliation(second_pool, second_assignment)
+
+      assert {:ok, %{inserted: [], conflicts: [scheduled_conflict], errors: []}} =
+               Jobs.enqueue_account_reconciliation_for_active_pools(trigger_kind: "scheduled")
+
+      refute gateway_job.conflict?
+      assert scheduled_conflict.conflict?
+      assert scheduled_conflict.id == gateway_job.id
+
+      assert gateway_job.args == %{
+               "pool_id" => second_pool.id,
+               "pool_upstream_assignment_id" => second_assignment.id,
+               "upstream_identity_id" => identity.id,
+               "target_kind" => "upstream_identity",
+               "trigger_kind" => "gateway"
+             }
+    end
+
+    test "concurrent gateway finalization enqueues one effective reconciliation job" do
+      {pool, assignment} = active_assignment_fixture(%{})
+      identity = Upstreams.get_upstream_identity(assignment.upstream_identity_id)
+
+      {second_pool, second_assignment} =
+        active_assignment_for_identity_fixture(identity,
+          assignment_label: "Concurrent gateway assignment",
+          created_at: DateTime.add(assignment.created_at, 60, :second)
+        )
+
+      targets =
+        [{pool, assignment}, {second_pool, second_assignment}]
+        |> Stream.cycle()
+        |> Enum.take(12)
+
+      results =
+        Enum.map(targets, fn {target_pool, target_assignment} ->
+          start_allowed_task(fn ->
+            Jobs.enqueue_gateway_account_reconciliation(target_pool, target_assignment)
+          end)
+        end)
+        |> Enum.map(&Task.await/1)
+
+      assert Enum.count(results, &match?({:ok, %{conflict?: false}}, &1)) == 1
+      assert Enum.count(results, &match?({:ok, %{conflict?: true}}, &1)) == 11
+
+      assert [job_id] =
+               results
+               |> Enum.map(fn {:ok, job} -> job.id end)
+               |> Enum.uniq()
+
+      assert [persisted_job] =
+               Repo.all(
+                 from(job in Oban.Job,
+                   where: job.worker == ^worker_name(AccountReconciliationWorker)
+                 )
+               )
+
+      assert persisted_job.id == job_id
+
+      Repo.delete_all(Oban.Job)
+
+      side_effect_results =
+        Enum.map(targets, fn {target_pool, target_assignment} ->
+          start_allowed_task(fn ->
+            SideEffects.maybe_enqueue_gateway_reconciliation(
+              target_pool.id,
+              target_assignment
+            )
+          end)
+        end)
+        |> Enum.map(&Task.await/1)
+
+      assert Enum.all?(side_effect_results, &(&1 == :ok))
+
+      assert [_single_job] =
+               Repo.all(
+                 from(job in Oban.Job,
+                   where: job.worker == ^worker_name(AccountReconciliationWorker)
+                 )
+               )
+    end
+
+    test "automatic reconciliation blocks incomplete jobs older than the cooldown" do
+      {pool, assignment} = active_assignment_fixture(%{})
+
+      for incomplete_state <- ~w(suspended available scheduled executing retryable) do
+        Repo.delete_all(Oban.Job)
+
+        assert {:ok, first_job} =
+                 Jobs.enqueue_gateway_account_reconciliation(pool, assignment)
+
+        expired_inserted_at =
+          DateTime.utc_now()
+          |> DateTime.add(-120, :second)
+          |> DateTime.truncate(:microsecond)
+
+        {1, _rows} =
+          from(job in Oban.Job, where: job.id == ^first_job.id)
+          |> Repo.update_all(set: [state: incomplete_state, inserted_at: expired_inserted_at])
+
+        assert {:ok, duplicate_job} =
+                 Jobs.enqueue_gateway_account_reconciliation(pool, assignment)
+
+        assert duplicate_job.conflict?
+        assert duplicate_job.id == first_job.id
+      end
+    end
+
+    test "automatic reconciliation cools down completion but not cancelled or discarded jobs" do
+      {pool, assignment} = active_assignment_fixture(%{})
+
+      assert {:ok, completed_job} =
+               Jobs.enqueue_gateway_account_reconciliation(pool, assignment)
+
+      {1, _rows} =
+        from(job in Oban.Job, where: job.id == ^completed_job.id)
+        |> Repo.update_all(set: [state: "completed"])
+
+      assert {:ok, completed_conflict} =
+               Jobs.enqueue_gateway_account_reconciliation(pool, assignment)
+
+      assert completed_conflict.conflict?
+      assert completed_conflict.id == completed_job.id
+
+      for retryable_terminal_state <- ~w(discarded cancelled) do
+        Repo.delete_all(Oban.Job)
+
+        assert {:ok, first_job} =
+                 Jobs.enqueue_gateway_account_reconciliation(pool, assignment)
+
+        {1, _rows} =
+          from(job in Oban.Job, where: job.id == ^first_job.id)
+          |> Repo.update_all(set: [state: retryable_terminal_state])
+
+        assert {:ok, replacement_job} =
+                 Jobs.enqueue_gateway_account_reconciliation(pool, assignment)
+
+        refute replacement_job.conflict?
+        assert replacement_job.id != first_job.id
+      end
+    end
+
+    test "gateway reconciliation can run again after the automatic cooldown expires" do
+      {pool, assignment} = active_assignment_fixture(%{})
+
+      assert {:ok, first_job} = Jobs.enqueue_gateway_account_reconciliation(pool, assignment)
+
+      expired_inserted_at =
+        DateTime.utc_now()
+        |> DateTime.add(-61, :second)
+        |> DateTime.truncate(:microsecond)
+
+      {1, _rows} =
+        from(job in Oban.Job, where: job.id == ^first_job.id)
+        |> Repo.update_all(set: [state: "completed", inserted_at: expired_inserted_at])
+
+      assert {:ok, later_job} = Jobs.enqueue_gateway_account_reconciliation(pool, assignment)
+
+      refute later_job.conflict?
+      assert later_job.id != first_job.id
     end
 
     test "manual reconciliation can target a non-canonical assignment for the same identity" do
@@ -2448,12 +2587,6 @@ defmodule CodexPooler.Jobs.ReconciliationJobsTest do
                "trigger_kind" => "manual"
              }
     end
-  end
-
-  defp publish_from_task(fun) when is_function(fun, 0) do
-    fun
-    |> Task.async()
-    |> Task.await(5_000)
   end
 
   defp start_allowed_task(fun) when is_function(fun, 0) do


### PR DESCRIPTION
## Summary

Fixes #166 by making scheduled and gateway-triggered account reconciliation share one automatic, identity-scoped deduplication boundary.

The production evidence showed that Oban was enforcing the configured key correctly. The duplicate work came from two different logical keys: scheduled jobs carried `upstream_identity_id`, while gateway jobs were keyed by `{pool_id, pool_upstream_assignment_id, trigger_kind}` and omitted the identity. That allowed scheduled and gateway jobs for the same upstream identity—and gateway jobs through separate assignments of that identity—to execute at the same time.

This PR keeps Oban 2.23's valid `states: :successful` group. It does not replace it with an explicit state list.

## Root cause

Before this change:

- scheduled reconciliation used identity-targeted args and incomplete-job uniqueness;
- gateway reconciliation used assignment + trigger uniqueness with a 60-second window;
- `trigger_kind` made scheduled and gateway jobs intentionally non-equivalent to Oban;
- gateway args did not contain `upstream_identity_id`, so assignments for the same identity were also independent;
- the Oban uniqueness period applies to incomplete states as well as completed jobs, so an executing/retryable/suspended job older than 60 seconds could fall outside the gateway query.

Sanitized production inspection confirmed scheduled and gateway reconciliation executions overlapping for the same assignment and upstream identity. No account identifiers, credentials, auth payloads, or provider bodies are included here or in the fixtures.

## Changes

- Add a dedicated `enqueue_gateway_account_reconciliation/2` API.
- Route scheduled and gateway automatic reconciliation through one identity-targeted enqueue path.
- Put `upstream_identity_id` and `target_kind: upstream_identity` in both automatic job arg shapes.
- Serialize automatic enqueue decisions with a short `FOR UPDATE` lock on the upstream identity so concurrent triggers/assignments cannot both pass the check-and-insert boundary.
- Check every incomplete Oban state without a time limit:
  - `suspended`
  - `available`
  - `scheduled`
  - `executing`
  - `retryable`
- Preserve `states: :successful` for the 60-second recent-completion cooldown. In Oban 2.23 this includes suspended, available, scheduled, executing, retryable, and completed.
- Allow cancelled/discarded work to be replaced immediately.
- Recognize legacy incomplete reconciliation rows that do not contain `upstream_identity_id` by resolving their assignment to the identity.
- Leave explicit/manual reconciliation assignment-targeted, so an operator can still request a non-canonical assignment intentionally.

## Resulting behavior

| Existing automatic job | New scheduled/gateway enqueue |
| --- | --- |
| Incomplete, any age | Reuses existing job |
| Completed within 60 seconds | Reuses existing job |
| Completed after 60 seconds | Inserts a new job |
| Cancelled or discarded | Inserts a replacement |
| Same identity through another Pool assignment | Reuses existing job |
| Concurrent scheduled/gateway requests | One insert; remaining results are conflicts |

## Regression coverage

The tests now prove:

- the real gateway finalization path reuses an incomplete scheduled job;
- scheduled fanout reuses an incomplete gateway job;
- 12 concurrent gateway enqueues across two Pool assignments create one persisted job and 11 conflicts;
- the gateway side-effect path also persists only one job under the same concurrency;
- incomplete jobs remain blockers after the 60-second completion cooldown, including `suspended`;
- completed jobs cool down for 60 seconds;
- cancelled/discarded jobs can be replaced;
- automatic reconciliation resumes after the cooldown;
- manual reconciliation remains assignment-targeted.

## Verification

- `mix compile --warnings-as-errors` — passed
- strict Credo on all five changed files — passed with no issues
- reconciliation, jobs, account-priming, and token-refresh suites — 133 passed
- concurrent gateway regression repeated across 20 additional randomized runs — passed every run
- broader jobs + gateway run — 937/938 passed; the sole failure is an existing environment-specific tokenizer oracle mismatch (`27` expected versus `28` from `codex_pooler:tiktoken`) in an untouched request-compression test
- `git diff --check` — passed

## Scope

This changes automatic reconciliation enqueueing only. It does not change token-refresh worker uniqueness, the token-refresh state machine, credentials, request payload logging, deployment configuration, or production data.

A separate late-follower usage-probe refresh race discovered during this audit is tracked in #170 and intentionally excluded from this PR.