### PR TITLE
fix(quota): make reset reconciliation self-healing

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -49,6 +49,7 @@ jobs_schedule = [
     icon: "hero-arrow-path-rounded-square",
     workers: [
       CodexPooler.Jobs.AccountReconciliationWorker,
+      CodexPooler.Jobs.AccountQuotaConfirmationWorker,
       CodexPooler.Jobs.AccountReconciliationEnqueueWorker
     ],
     scheduled_worker: CodexPooler.Jobs.AccountReconciliationEnqueueWorker,

--- a/lib/codex_pooler/jobs/upstream_enqueue.ex
+++ b/lib/codex_pooler/jobs/upstream_enqueue.ex
@@ -29,7 +29,7 @@ defmodule CodexPooler.Jobs.UpstreamEnqueue do
   @type job_insert_result ::
           {:ok, Oban.Job.t()} | {:error, Ecto.Changeset.t() | missing_ref_error()}
 
-  @automatic_reconciliation_unique [
+  @identity_reconciliation_unique [
     fields: [:args, :queue, :worker],
     keys: [:upstream_identity_id],
     states: :successful,
@@ -112,33 +112,42 @@ defmodule CodexPooler.Jobs.UpstreamEnqueue do
         %PoolUpstreamAssignment{} = assignment,
         opts \\ []
       ) do
-    enqueue_automatic_identity_account_reconciliation(
+    enqueue_identity_account_reconciliation(
       assignment.pool_id,
       assignment,
       Keyword.put_new(opts, :trigger_kind, "scheduled")
     )
   end
 
-  @spec enqueue_gateway_account_reconciliation(pool_ref(), PoolUpstreamAssignment.t()) ::
-          job_insert_result()
-  def enqueue_gateway_account_reconciliation(pool_or_id, %PoolUpstreamAssignment{} = assignment) do
+  @spec enqueue_identity_account_reconciliation(
+          pool_ref(),
+          PoolUpstreamAssignment.t(),
+          keyword()
+        ) :: job_insert_result()
+  def enqueue_identity_account_reconciliation(
+        pool_or_id,
+        %PoolUpstreamAssignment{} = assignment,
+        opts \\ []
+      ) do
     with {:ok, pool_id} <- pool_id(pool_or_id) do
-      enqueue_automatic_identity_account_reconciliation(
-        pool_id,
-        assignment,
-        trigger_kind: "gateway"
-      )
+      enqueue_identity_scoped_account_reconciliation(pool_id, assignment, opts)
     end
   end
 
-  # Scheduled and gateway triggers share one automatic dedup boundary per
-  # upstream identity: an incomplete job of either shape blocks a new insert
+  @spec enqueue_gateway_account_reconciliation(pool_ref(), PoolUpstreamAssignment.t()) ::
+          job_insert_result()
+  def enqueue_gateway_account_reconciliation(pool_or_id, %PoolUpstreamAssignment{} = assignment) do
+    enqueue_identity_account_reconciliation(pool_or_id, assignment, trigger_kind: "gateway")
+  end
+
+  # Scheduled, gateway, and admin triggers share one dedup boundary per
+  # upstream identity: an incomplete job of any shape blocks a new insert
   # regardless of age, a completed job imposes the 60-second inserted-at
   # cooldown from the Oban unique config, and cancelled/discarded jobs are
   # replaceable immediately. The check-then-insert pair is deliberately not
   # serialized here: a racing enqueue falls through to Oban's advisory-locked
   # unique insert and resolves as conflict?: true.
-  defp enqueue_automatic_identity_account_reconciliation(pool_id, assignment, opts) do
+  defp enqueue_identity_scoped_account_reconciliation(pool_id, assignment, opts) do
     args =
       pool_id
       |> account_reconciliation_args(assignment.id, opts)
@@ -148,19 +157,19 @@ defmodule CodexPooler.Jobs.UpstreamEnqueue do
       })
       |> maybe_put_recovery_fence(assignment)
 
-    case incomplete_automatic_reconciliation_job(assignment.upstream_identity_id) do
+    case incomplete_identity_reconciliation_job(assignment.upstream_identity_id) do
       %Oban.Job{} = job ->
         {:ok, %{job | conflict?: true}}
 
       nil ->
         args
-        |> AccountReconciliationWorker.new(automatic_reconciliation_job_options(opts))
+        |> AccountReconciliationWorker.new(identity_reconciliation_job_options(opts))
         |> Oban.insert()
     end
     |> tap_job_status_event(pool_id, "account_reconciliation", "scheduled")
   end
 
-  defp incomplete_automatic_reconciliation_job(identity_id) do
+  defp incomplete_identity_reconciliation_job(identity_id) do
     worker = Oban.Worker.to_string(AccountReconciliationWorker)
 
     Oban.Job
@@ -189,10 +198,22 @@ defmodule CodexPooler.Jobs.UpstreamEnqueue do
     |> Repo.one()
   end
 
-  defp automatic_reconciliation_job_options(opts) do
+  defp identity_reconciliation_job_options(opts) do
     opts
     |> Keyword.take([:scheduled_at, :schedule_in])
-    |> Keyword.put(:unique, @automatic_reconciliation_unique)
+    |> Keyword.put(:unique, identity_reconciliation_unique(opts))
+  end
+
+  # A quota confirmation must run after its evidence span even when another
+  # reconciliation completed inside the normal 60-second enqueue cooldown.
+  # The explicit incomplete-job query above still prevents overlap, while this
+  # narrower Oban boundary retains advisory-lock protection for enqueue races.
+  defp identity_reconciliation_unique(opts) do
+    if Keyword.get(opts, :bypass_successful_cooldown?, false) do
+      Keyword.put(@identity_reconciliation_unique, :states, :incomplete)
+    else
+      @identity_reconciliation_unique
+    end
   end
 
   defp tap_job_status_event(

--- a/lib/codex_pooler/jobs/workers/upstreams/account_quota_confirmation_worker.ex
+++ b/lib/codex_pooler/jobs/workers/upstreams/account_quota_confirmation_worker.ex
@@ -1,0 +1,142 @@
+defmodule CodexPooler.Jobs.AccountQuotaConfirmationWorker do
+  @moduledoc """
+  Confirms a reset-shaped weekly usage observation after the safety span.
+
+  Manual quota refreshes enqueue this worker only when their first provider
+  observation leaves a pending zero candidate. The delayed probe is a distinct
+  worker so it cannot collide with the reconciliation job that discovered the
+  candidate.
+  """
+
+  use Oban.Worker,
+    queue: :jobs,
+    max_attempts: 1,
+    tags: ["account_reconciliation", "quota_confirmation"],
+    unique: [
+      fields: [:args, :queue, :worker],
+      keys: [:upstream_identity_id],
+      states: :incomplete,
+      period: {15, :minutes}
+    ]
+
+  alias CodexPooler.Jobs.UpstreamEnqueue
+  alias CodexPooler.Upstreams.Assignments.PoolAssignments
+  alias CodexPooler.Upstreams.Quota.Windows
+  alias CodexPooler.Upstreams.Quota.Windows.EvidenceStore
+  alias CodexPooler.Upstreams.Schemas.{PoolUpstreamAssignment, UpstreamIdentity}
+
+  @manual_triggers ~w(admin_upstreams_live admin_upstream_cockpit_live)
+  @settle_buffer_seconds 5
+  @reconcilable_statuses [
+    PoolUpstreamAssignment.active_status(),
+    PoolUpstreamAssignment.refresh_due_status(),
+    PoolUpstreamAssignment.refresh_failed_status()
+  ]
+
+  @spec enqueue_if_pending(map(), String.t()) ::
+          :not_needed | {:ok, Oban.Job.t()} | {:error, Ecto.Changeset.t()}
+  def enqueue_if_pending(
+        %{
+          identity: %UpstreamIdentity{} = identity,
+          assignment: %PoolUpstreamAssignment{} = assignment
+        },
+        trigger_kind
+      )
+      when trigger_kind in @manual_triggers do
+    case pending_zero_confirmation(identity.id) do
+      %{due_at: due_at, observed_at: observed_at} ->
+        %{
+          "pool_id" => assignment.pool_id,
+          "pool_upstream_assignment_id" => assignment.id,
+          "upstream_identity_id" => identity.id,
+          "target_kind" => "upstream_identity",
+          "trigger_kind" => "admin_quota_confirmation",
+          "confirmation_candidate_observed_at" => DateTime.to_iso8601(observed_at)
+        }
+        |> new(scheduled_at: DateTime.add(due_at, @settle_buffer_seconds, :second))
+        |> Oban.insert()
+
+      nil ->
+        :not_needed
+    end
+  end
+
+  def enqueue_if_pending(_result, _trigger_kind), do: :not_needed
+
+  @impl Oban.Worker
+  def timeout(%Oban.Job{}), do: :timer.minutes(20)
+
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"upstream_identity_id" => identity_id}}) do
+    timestamp = now()
+
+    case pending_zero_confirmation(identity_id, timestamp) do
+      %{due_at: due_at} ->
+        maybe_enqueue_confirmation(identity_id, due_at, timestamp)
+
+      nil ->
+        :ok
+    end
+  end
+
+  defp maybe_enqueue_confirmation(identity_id, due_at, timestamp) do
+    remaining_seconds = DateTime.diff(due_at, timestamp, :second)
+
+    cond do
+      remaining_seconds > 0 ->
+        {:snooze, remaining_seconds + @settle_buffer_seconds}
+
+      assignment = reconcilable_assignment(identity_id) ->
+        enqueue_reconciliation(assignment, due_at)
+
+      true ->
+        :ok
+    end
+  end
+
+  defp enqueue_reconciliation(%PoolUpstreamAssignment{} = assignment, due_at) do
+    case UpstreamEnqueue.enqueue_identity_account_reconciliation(
+           assignment.pool_id,
+           assignment,
+           trigger_kind: "admin_quota_confirmation",
+           bypass_successful_cooldown?: true
+         ) do
+      {:ok, %Oban.Job{conflict?: true} = job} -> confirmation_conflict_result(job, due_at)
+      {:ok, %Oban.Job{}} -> :ok
+      {:error, _reason} -> {:error, "quota confirmation reconciliation enqueue failed"}
+    end
+  end
+
+  defp confirmation_conflict_result(
+         %Oban.Job{state: "executing", attempted_at: %DateTime{} = attempted_at},
+         due_at
+       ) do
+    if DateTime.compare(attempted_at, due_at) == :lt, do: {:snooze, 30}, else: :ok
+  end
+
+  defp confirmation_conflict_result(%Oban.Job{state: state}, _due_at)
+       when state in ["suspended", "executing"],
+       do: {:snooze, 60}
+
+  defp confirmation_conflict_result(%Oban.Job{}, _due_at), do: :ok
+
+  defp pending_zero_confirmation(identity_id, timestamp \\ now()) do
+    identity_id
+    |> Windows.list_evidence()
+    |> Enum.flat_map(fn window ->
+      case EvidenceStore.pending_weekly_zero_confirmation(window, timestamp) do
+        {:ok, confirmation} -> [confirmation]
+        :none -> []
+      end
+    end)
+    |> Enum.min_by(&DateTime.to_unix(&1.due_at, :microsecond), fn -> nil end)
+  end
+
+  defp reconcilable_assignment(identity_id) do
+    identity_id
+    |> PoolAssignments.list_pool_assignments_for_identity()
+    |> Enum.find(&(&1.status in @reconcilable_statuses))
+  end
+
+  defp now, do: DateTime.utc_now() |> DateTime.truncate(:microsecond)
+end

--- a/lib/codex_pooler/jobs/workers/upstreams/account_reconciliation_worker.ex
+++ b/lib/codex_pooler/jobs/workers/upstreams/account_reconciliation_worker.ex
@@ -17,6 +17,7 @@ defmodule CodexPooler.Jobs.AccountReconciliationWorker do
       period: {7, :days}
     ]
 
+  alias CodexPooler.Jobs.AccountQuotaConfirmationWorker
   alias CodexPooler.Upstreams.Lifecycle.CredentialFencing
   alias CodexPooler.Upstreams.Reconciliation.AccountReconciliation
 
@@ -62,7 +63,8 @@ defmodule CodexPooler.Jobs.AccountReconciliationWorker do
     if recovery_probe_required?(args) do
       trigger_kind = Map.get(args, "trigger_kind", "manual")
 
-      with {:ok, result} <- AccountReconciliation.run(pool_id, assignment_id, trigger_kind) do
+      with {:ok, result} <- AccountReconciliation.run(pool_id, assignment_id, trigger_kind),
+           :ok <- enqueue_quota_confirmation(result, trigger_kind) do
         reconciliation_outcome(result)
       end
     else
@@ -80,6 +82,14 @@ defmodule CodexPooler.Jobs.AccountReconciliationWorker do
   end
 
   defp recovery_probe_required?(_args), do: true
+
+  defp enqueue_quota_confirmation(result, trigger_kind) do
+    case AccountQuotaConfirmationWorker.enqueue_if_pending(result, trigger_kind) do
+      :not_needed -> :ok
+      {:ok, %Oban.Job{}} -> :ok
+      {:error, _changeset} -> {:error, "quota confirmation enqueue failed"}
+    end
+  end
 
   @impl Oban.Worker
   def backoff(%Oban.Job{attempt: attempt}) do

--- a/lib/codex_pooler/upstreams.ex
+++ b/lib/codex_pooler/upstreams.ex
@@ -14,6 +14,7 @@ defmodule CodexPooler.Upstreams do
     Assignments,
     Import,
     OAuth,
+    QuotaReconciliationEnqueue,
     SavedResetPolicy,
     SavedResetRedemptionEnqueue,
     SecretStore,
@@ -171,6 +172,12 @@ defmodule CodexPooler.Upstreams do
           {:ok, map()} | {:error, lifecycle_error() | Ecto.Changeset.t()}
   defdelegate enqueue_token_refresh_for_scope(scope, identity_or_id, opts \\ []),
     to: TokenRefreshEnqueue,
+    as: :enqueue_for_scope
+
+  @spec enqueue_quota_reconciliation_for_scope(Scope.t(), identity_ref(), keyword()) ::
+          {:ok, map()} | {:error, lifecycle_error() | Ecto.Changeset.t()}
+  defdelegate enqueue_quota_reconciliation_for_scope(scope, identity_or_id, opts \\ []),
+    to: QuotaReconciliationEnqueue,
     as: :enqueue_for_scope
 
   @spec update_saved_reset_policy_for_scope(Scope.t(), identity_ref(), map()) ::

--- a/lib/codex_pooler/upstreams/quota/windows/evidence_store.ex
+++ b/lib/codex_pooler/upstreams/quota/windows/evidence_store.ex
@@ -29,6 +29,16 @@ defmodule CodexPooler.Upstreams.Quota.Windows.EvidenceStore do
           required(:reset_at) => DateTime.t(),
           required(:observed_at) => DateTime.t()
         }
+  @type pending_confirmation :: %{
+          required(:used_percent) => Decimal.t(),
+          required(:reset_at) => DateTime.t(),
+          required(:observed_at) => DateTime.t(),
+          required(:due_at) => DateTime.t()
+        }
+
+  @spec weekly_restart_confirmation_span_seconds() :: pos_integer()
+  def weekly_restart_confirmation_span_seconds,
+    do: @weekly_restart_confirmation_span_seconds
 
   @spec evidence_changeset(identity_ref(), map(), DateTime.t()) ::
           {:ok, Ecto.Changeset.t()} | {:error, Evidence.errors() | map()}
@@ -197,6 +207,34 @@ defmodule CodexPooler.Upstreams.Quota.Windows.EvidenceStore do
 
   def candidate_valid?(_candidate, _timestamp), do: false
 
+  @spec pending_weekly_zero_confirmation(Quota.AccountQuotaWindow.t(), DateTime.t()) ::
+          {:ok, pending_confirmation()} | :none
+  def pending_weekly_zero_confirmation(
+        %Quota.AccountQuotaWindow{} = window,
+        %DateTime{} = timestamp
+      ) do
+    with true <- account_weekly_evidence?(window),
+         {:ok, %{used_percent: used_percent} = candidate} <-
+           parse_candidate(window.metadata || %{}),
+         true <- zero_percent?(used_percent),
+         true <- candidate_valid?(candidate, timestamp) do
+      {:ok,
+       Map.put(
+         candidate,
+         :due_at,
+         DateTime.add(
+           candidate.observed_at,
+           @weekly_restart_confirmation_span_seconds,
+           :second
+         )
+       )}
+    else
+      _not_pending -> :none
+    end
+  end
+
+  def pending_weekly_zero_confirmation(_window, _timestamp), do: :none
+
   @spec clear_candidate(map()) :: map()
   def clear_candidate(metadata) when is_map(metadata),
     do: Map.delete(metadata, @candidate_metadata_key)
@@ -301,7 +339,7 @@ defmodule CodexPooler.Upstreams.Quota.Windows.EvidenceStore do
          %Evidence{} = evidence,
          timestamp
        ) do
-    if uncorroborated_zero_reenable_attempt?(evidence, existing, timestamp) do
+    if unconfirmed_weekly_zero_transition?(evidence, existing, timestamp) do
       sliding_restart_attrs(existing, attrs, evidence, timestamp)
     else
       merge_attrs_by_decision(existing, attrs, evidence, timestamp)
@@ -319,9 +357,12 @@ defmodule CodexPooler.Upstreams.Quota.Windows.EvidenceStore do
   # with observation time, while a cached body keeps a fixed reset. Accept the
   # zero only when a stored candidate and the incoming observation prove that
   # sliding-live shape across the confirmation span; otherwise keep the
-  # exhausted row and let the candidate age or restart. Anchored resets (the 5h
-  # shape, should it return) never slide, so they keep taking the pre-existing
-  # anchored + corroboration path untouched.
+  # canonical row and let the candidate age or restart. This applies after the
+  # zero is accepted too: periodically reconfirming live zeroes advances their
+  # observation time before the freshness TTL, while cached fixed-reset bodies
+  # fail the sliding proof and age out. Anchored resets (the 5h shape, should it
+  # return) never slide, so they keep taking the pre-existing anchored +
+  # corroboration path untouched.
   defp sliding_restart_attrs(existing, attrs, evidence, timestamp) do
     metadata = existing.metadata || %{}
     decision = restart_candidate_decision(metadata, existing, evidence, timestamp)
@@ -396,7 +437,7 @@ defmodule CodexPooler.Upstreams.Quota.Windows.EvidenceStore do
           nil
       end
 
-    Logger.info(
+    Logger.debug(
       "quota_restart_decision decision=#{decision} " <>
         "upstream_identity_id=#{existing.upstream_identity_id} " <>
         "quota_key=#{evidence.quota_key} window_kind=#{evidence.window_kind} " <>
@@ -471,26 +512,24 @@ defmodule CodexPooler.Upstreams.Quota.Windows.EvidenceStore do
 
   defp sliding_live_reset?(_candidate, _evidence), do: false
 
-  # A usage-endpoint zero must never re-enable exhausted weekly quota on its
-  # own: without this chokepoint guard, an expired or stale canonical takes
-  # the `:incoming` fast paths, and capacity- or credit-bearing shapes exit
-  # the weak-capacity quarantine as `:continue` into the generic merge — all
-  # single-observation routes around the corroboration requirement. Any
-  # account-weekly zero replacing an exhausted canonical needs independent
-  # runtime corroboration first, regardless of freshness or capacity shape.
-  defp uncorroborated_zero_reenable_attempt?(
+  # A usage-endpoint zero must never lower or refresh canonical weekly quota on
+  # its own. Without this chokepoint, non-exhausted rows can reject live zeroes
+  # forever, while an accepted zero stops advancing `observed_at` and becomes
+  # stale exactly one freshness TTL later. Route every account-weekly zero
+  # through the same cache-safe candidate confirmation unless independent
+  # runtime evidence already corroborates the transition.
+  defp unconfirmed_weekly_zero_transition?(
          %Evidence{source: "codex_usage_api", used_percent: %Decimal{}} = evidence,
          %Quota.AccountQuotaWindow{used_percent: %Decimal{}} = existing,
          timestamp
        ) do
     account_weekly_evidence?(evidence) and
       zero_percent?(evidence.used_percent) and
-      exhausted_by_used_percent?(existing) and
       same_evidence_identity?(evidence, existing) and
       not runtime_weekly_restart_corroborated?(evidence, existing, timestamp)
   end
 
-  defp uncorroborated_zero_reenable_attempt?(_evidence, _existing, _timestamp), do: false
+  defp unconfirmed_weekly_zero_transition?(_evidence, _existing, _timestamp), do: false
 
   defp account_weekly_evidence?(evidence) do
     account_quota_identity?(evidence) and Map.get(evidence, :window_kind) == "secondary" and

--- a/lib/codex_pooler/upstreams/quota_reconciliation_enqueue.ex
+++ b/lib/codex_pooler/upstreams/quota_reconciliation_enqueue.ex
@@ -1,0 +1,82 @@
+defmodule CodexPooler.Upstreams.QuotaReconciliationEnqueue do
+  @moduledoc false
+
+  alias CodexPooler.Accounts.Scope
+  alias CodexPooler.Jobs.UpstreamEnqueue
+  alias CodexPooler.Repo
+
+  alias CodexPooler.Upstreams.Assignments.PoolAssignments
+  alias CodexPooler.Upstreams.Lifecycle.{AccountAudit, AccountLifecycle}
+  alias CodexPooler.Upstreams.Schemas.{PoolUpstreamAssignment, UpstreamIdentity}
+  alias CodexPooler.Upstreams.Secrets
+
+  @reconcilable_assignment_statuses [
+    PoolUpstreamAssignment.active_status(),
+    PoolUpstreamAssignment.refresh_due_status(),
+    PoolUpstreamAssignment.refresh_failed_status()
+  ]
+  @deleted_assignment PoolUpstreamAssignment.deleted_status()
+
+  @type lifecycle_error :: CodexPooler.Upstreams.lifecycle_error()
+  @type identity_ref :: UpstreamIdentity.t() | Ecto.UUID.t()
+
+  @spec enqueue_for_scope(Scope.t(), identity_ref(), keyword()) ::
+          {:ok, map()} | {:error, lifecycle_error() | Ecto.Changeset.t()}
+  def enqueue_for_scope(scope, identity_or_id, opts \\ [])
+
+  def enqueue_for_scope(%Scope{} = scope, identity_or_id, opts) when is_list(opts) do
+    trigger_kind = Keyword.get(opts, :trigger_kind, "admin_upstreams_live")
+
+    with {:ok, identity} <- AccountLifecycle.authorize(scope, identity_or_id),
+         assignments = linked_assignments(identity),
+         [_first | _rest] = candidates <- reconcilable_assignments(assignments),
+         {:ok, job} <- enqueue_one(candidates, opts, trigger_kind) do
+      result = %{
+        status: if(job.conflict?, do: :already_queued, else: :queued),
+        identity: Repo.reload!(identity),
+        assignments: assignments,
+        secret_status: Secrets.secret_status(identity),
+        job: job
+      }
+
+      {:ok, result}
+      |> AccountAudit.record_change(scope, "upstream_account.quota_reconciliation_enqueue",
+        trigger_kind: trigger_kind,
+        job_conflict?: job.conflict?
+      )
+    else
+      [] ->
+        {:error,
+         CodexPooler.Upstreams.lifecycle_error(
+           :quota_reconciliation_unavailable,
+           "no active pool assignment is available for quota refresh"
+         )}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  def enqueue_for_scope(_scope, _identity_or_id, _opts),
+    do:
+      {:error, CodexPooler.Upstreams.lifecycle_error(:invalid_request, "user scope is required")}
+
+  defp linked_assignments(identity) do
+    identity.id
+    |> PoolAssignments.list_pool_assignments_for_identity()
+    |> Enum.reject(&(&1.status == @deleted_assignment))
+  end
+
+  defp reconcilable_assignments(assignments) do
+    assignments
+    |> Enum.filter(&(&1.status in @reconcilable_assignment_statuses))
+  end
+
+  defp enqueue_one([assignment | _rest], opts, trigger_kind) do
+    UpstreamEnqueue.enqueue_identity_account_reconciliation(
+      assignment.pool_id,
+      assignment,
+      Keyword.put(opts, :trigger_kind, trigger_kind)
+    )
+  end
+end

--- a/lib/codex_pooler/upstreams/reconciliation/account_reconciliation.ex
+++ b/lib/codex_pooler/upstreams/reconciliation/account_reconciliation.ex
@@ -11,16 +11,24 @@ defmodule CodexPooler.Upstreams.Reconciliation.AccountReconciliation do
   alias CodexPooler.Upstreams.Assignments.PoolAssignments
   alias CodexPooler.Upstreams.Quota
   alias CodexPooler.Upstreams.Quota.Windows, as: QuotaWindows
+  alias CodexPooler.Upstreams.Quota.Windows.EvidenceStore
   alias CodexPooler.Upstreams.Reconciliation.PoolReconciliation
   alias CodexPooler.Upstreams.Schemas.{PoolUpstreamAssignment, UpstreamIdentity}
 
   @stale_after_seconds 25 * 60
   @successful_partial_codes ~w(catalog_sync_failed catalog_sync_in_progress)
-  @catalog_sync_skipped_triggers ~w(scheduled gateway)
+  @catalog_sync_skipped_triggers ~w(
+    scheduled
+    gateway
+    admin_upstreams_live
+    admin_upstream_cockpit_live
+    admin_quota_confirmation
+  )
   @paused UpstreamIdentity.paused_status()
   @reauth_required UpstreamIdentity.reauth_required_status()
   @assignment_paused PoolUpstreamAssignment.paused_status()
   @assignment_reauth_required PoolUpstreamAssignment.reauth_required_status()
+  @assignment_deleted PoolUpstreamAssignment.deleted_status()
 
   @type orchestration_result :: {:ok, map()} | {:error, term()}
 
@@ -296,15 +304,29 @@ defmodule CodexPooler.Upstreams.Reconciliation.AccountReconciliation do
 
     {:ok, assignment} = Quota.PrimingState.record(assignment.pool_id, assignment, details)
 
+    identity.id
+    |> PoolAssignments.list_pool_assignments_for_identity()
+    |> Enum.reject(&(&1.id == assignment.id or &1.status == @assignment_deleted))
+    |> Enum.each(fn sibling ->
+      {:ok, _sibling} = Quota.PrimingState.record(sibling.pool_id, sibling, details)
+    end)
+
     assignment
   end
 
   defp quota_priming_summary(identity, timestamp) do
     windows = QuotaWindows.list_quota_windows(identity)
 
+    pending_confirmations =
+      identity
+      |> QuotaWindows.list_evidence()
+      |> pending_weekly_zero_confirmations(timestamp)
+
     %{
       timestamp: timestamp,
       windows: windows,
+      confirmation_pending_count: length(pending_confirmations),
+      confirmation_due_at: earliest_confirmation_due_at(pending_confirmations),
       account_primary_usable_count:
         Enum.count(windows, &account_primary_usable_window?(&1, timestamp)),
       usable_count: Enum.count(windows, &QuotaWindows.usable_window?(&1, timestamp)),
@@ -330,8 +352,10 @@ defmodule CodexPooler.Upstreams.Reconciliation.AccountReconciliation do
       "usable_window_count" => summary.usable_count,
       "reset_bearing_window_count" => summary.reset_bearing_count,
       "stale_window_count" => summary.stale_count,
-      "expired_window_count" => summary.expired_count
+      "expired_window_count" => summary.expired_count,
+      "confirmation_pending_count" => summary.confirmation_pending_count
     }
+    |> maybe_put_confirmation_due_at(summary.confirmation_due_at)
   end
 
   defp quota_priming_status(_status, %{status: :failed}, _summary),
@@ -339,6 +363,14 @@ defmodule CodexPooler.Upstreams.Reconciliation.AccountReconciliation do
 
   defp quota_priming_status(:failed, _quota_step, _summary),
     do: "failed"
+
+  defp quota_priming_status(
+         _status,
+         _quota_step,
+         %{confirmation_pending_count: count}
+       )
+       when count > 0,
+       do: "confirmation_pending"
 
   defp quota_priming_status(_status, _quota_step, %{account_primary_usable_count: count})
        when count > 0,
@@ -366,6 +398,29 @@ defmodule CodexPooler.Upstreams.Reconciliation.AccountReconciliation do
 
   defp quota_priming_status(_status, _quota_step, %{windows: []}),
     do: "unprimed"
+
+  defp pending_weekly_zero_confirmations(windows, timestamp) do
+    Enum.flat_map(windows, fn window ->
+      case EvidenceStore.pending_weekly_zero_confirmation(window, timestamp) do
+        {:ok, confirmation} -> [confirmation]
+        :none -> []
+      end
+    end)
+  end
+
+  defp earliest_confirmation_due_at([]), do: nil
+
+  defp earliest_confirmation_due_at(confirmations) do
+    confirmations
+    |> Enum.min_by(&DateTime.to_unix(&1.due_at, :microsecond))
+    |> Map.fetch!(:due_at)
+  end
+
+  defp maybe_put_confirmation_due_at(details, %DateTime{} = due_at) do
+    Map.put(details, "confirmation_due_at", DateTime.to_iso8601(due_at))
+  end
+
+  defp maybe_put_confirmation_due_at(details, nil), do: details
 
   defp account_primary_usable_window?(window, timestamp) do
     (WindowClassifier.primary_5h?(window) or WindowClassifier.monthly_primary?(window)) and

--- a/lib/codex_pooler_web/live/admin/components/pages/upstreams/account_card.ex
+++ b/lib/codex_pooler_web/live/admin/components/pages/upstreams/account_card.ex
@@ -598,6 +598,16 @@ defmodule CodexPoolerWeb.Admin.UpstreamPageComponents.AccountCard do
         </li>
         <li>
           <AdminComponents.dropdown_action_item
+            id={"reconcile-upstream-account-#{@account.identity.id}"}
+            icon="hero-arrow-path"
+            label="Refresh quota"
+            phx-click="reconcile_account"
+            phx-value-id={@account.identity.id}
+            disabled={!refreshable?(@account.identity.status)}
+          />
+        </li>
+        <li>
+          <AdminComponents.dropdown_action_item
             id={"saved-reset-policy-upstream-account-#{@account.identity.id}"}
             icon="hero-battery-100"
             label="Saved resets"

--- a/lib/codex_pooler_web/live/admin/components/pages/upstreams/cockpit/sections.ex
+++ b/lib/codex_pooler_web/live/admin/components/pages/upstreams/cockpit/sections.ex
@@ -233,6 +233,14 @@ defmodule CodexPoolerWeb.Admin.UpstreamCockpitComponents.Sections do
           phx-value-id={@cockpit.identity.id}
         />
         <.cockpit_action_button
+          id={"cockpit-reconcile-upstream-account-#{@cockpit.identity.id}"}
+          label="Refresh quota"
+          icon="hero-arrow-path"
+          action={@cockpit.actions.reconcile_quota}
+          phx-click="reconcile_account"
+          phx-value-id={@cockpit.identity.id}
+        />
+        <.cockpit_action_button
           id={"cockpit-redeem-saved-reset-upstream-account-#{@cockpit.identity.id}"}
           label="Redeem saved reset"
           action={@cockpit.actions.redeem_saved_reset}

--- a/lib/codex_pooler_web/live/admin/components/shared/badge_components.ex
+++ b/lib/codex_pooler_web/live/admin/components/shared/badge_components.ex
@@ -76,7 +76,8 @@ defmodule CodexPoolerWeb.Admin.BadgeComponents do
            ] ->
         chip_class(:error)
 
-      status when status in ["in_progress", "pending", "refreshing", "stale"] ->
+      status
+      when status in ["in_progress", "pending", "refreshing", "confirmation_pending", "stale"] ->
         chip_class(:info)
 
       _status ->

--- a/lib/codex_pooler_web/live/admin/pages/upstream_cockpit_live.ex
+++ b/lib/codex_pooler_web/live/admin/pages/upstream_cockpit_live.ex
@@ -114,6 +114,10 @@ defmodule CodexPoolerWeb.Admin.UpstreamCockpitLive do
     {:noreply, AccountLifecycleWorkflow.refresh(socket, identity_id, &load_cockpit/1)}
   end
 
+  def handle_event("reconcile_account", %{"id" => identity_id}, socket) do
+    {:noreply, AccountLifecycleWorkflow.reconcile(socket, identity_id, &load_cockpit/1)}
+  end
+
   def handle_event("open_import_auth_json", params, socket) do
     identity_id = Map.get(params, "id", socket.assigns.cockpit.identity.id)
 

--- a/lib/codex_pooler_web/live/admin/pages/upstream_cockpit_live/account_lifecycle_workflow.ex
+++ b/lib/codex_pooler_web/live/admin/pages/upstream_cockpit_live/account_lifecycle_workflow.ex
@@ -102,6 +102,22 @@ defmodule CodexPoolerWeb.Admin.UpstreamCockpitLive.AccountLifecycleWorkflow do
     end
   end
 
+  @spec reconcile(Phoenix.LiveView.Socket.t(), Ecto.UUID.t(), (Phoenix.LiveView.Socket.t() ->
+                                                                 Phoenix.LiveView.Socket.t())) ::
+          Phoenix.LiveView.Socket.t()
+  def reconcile(socket, identity_id, reload_fun) do
+    cond do
+      identity_id != socket.assigns.cockpit.identity.id ->
+        put_flash(socket, :error, "Upstream account was not found")
+
+      action_available?(socket, :reconcile_quota, identity_id) ->
+        enqueue_quota_reconciliation(socket, identity_id, reload_fun)
+
+      true ->
+        put_unavailable_action_error(socket, :reconcile_quota)
+    end
+  end
+
   @spec open_delete(Phoenix.LiveView.Socket.t(), Ecto.UUID.t()) :: Phoenix.LiveView.Socket.t()
   def open_delete(socket, identity_id) do
     if action_available?(socket, :delete, identity_id) do
@@ -203,6 +219,28 @@ defmodule CodexPoolerWeb.Admin.UpstreamCockpitLive.AccountLifecycleWorkflow do
     end
   end
 
+  defp enqueue_quota_reconciliation(socket, identity_id, reload_fun) do
+    case Upstreams.enqueue_quota_reconciliation_for_scope(
+           socket.assigns.current_scope,
+           identity_id,
+           trigger_kind: @reason
+         ) do
+      {:ok, %{status: status}} ->
+        message =
+          if status == :already_queued,
+            do: "Quota refresh is already queued",
+            else:
+              "Quota refresh queued; reset changes, if detected, are confirmed automatically after about 3 minutes"
+
+        socket
+        |> put_flash(:info, message)
+        |> reload_fun.()
+
+      {:error, reason} ->
+        put_flash(socket, :error, error_message(reason))
+    end
+  end
+
   defp validate_delete_confirmation(%{id: id, label: label}, %{
          "id" => id,
          "confirmation_label" => confirmation
@@ -244,6 +282,7 @@ defmodule CodexPoolerWeb.Admin.UpstreamCockpitLive.AccountLifecycleWorkflow do
   end
 
   defp action_label(:refresh_token), do: "Refresh token"
+  defp action_label(:reconcile_quota), do: "Refresh quota"
 
   defp action_label(action_key),
     do: action_key |> to_string() |> String.replace("_", " ") |> String.capitalize()

--- a/lib/codex_pooler_web/live/admin/pages/upstreams_live.ex
+++ b/lib/codex_pooler_web/live/admin/pages/upstreams_live.ex
@@ -344,6 +344,10 @@ defmodule CodexPoolerWeb.Admin.UpstreamsLive do
     {:noreply, AccountLifecycleWorkflow.refresh(socket, identity_id, &reload_upstreams/1)}
   end
 
+  def handle_event("reconcile_account", %{"id" => identity_id}, socket) do
+    {:noreply, AccountLifecycleWorkflow.reconcile(socket, identity_id, &reload_upstreams/1)}
+  end
+
   defp refresh_editing_saved_reset_policy(socket, identity_id) do
     case find_account(socket.assigns.upstream_accounts, identity_id) do
       nil -> close_saved_reset_policy_dialog(socket)

--- a/lib/codex_pooler_web/live/admin/pages/upstreams_live/account_lifecycle_workflow.ex
+++ b/lib/codex_pooler_web/live/admin/pages/upstreams_live/account_lifecycle_workflow.ex
@@ -56,6 +56,31 @@ defmodule CodexPoolerWeb.Admin.UpstreamsLive.AccountLifecycleWorkflow do
     end
   end
 
+  @spec reconcile(Phoenix.LiveView.Socket.t(), Ecto.UUID.t(), (Phoenix.LiveView.Socket.t() ->
+                                                                 Phoenix.LiveView.Socket.t())) ::
+          Phoenix.LiveView.Socket.t()
+  def reconcile(socket, identity_id, reload_fun) do
+    case Upstreams.enqueue_quota_reconciliation_for_scope(
+           socket.assigns.current_scope,
+           identity_id,
+           trigger_kind: "admin_upstreams_live"
+         ) do
+      {:ok, %{status: status}} ->
+        message =
+          if status == :already_queued,
+            do: "Quota refresh is already queued",
+            else:
+              "Quota refresh queued; reset changes, if detected, are confirmed automatically after about 3 minutes"
+
+        socket
+        |> put_flash(:info, message)
+        |> reload_fun.()
+
+      {:error, reason} ->
+        put_flash(socket, :error, WorkflowError.message(reason))
+    end
+  end
+
   @spec open_delete(Phoenix.LiveView.Socket.t(), Ecto.UUID.t()) :: Phoenix.LiveView.Socket.t()
   def open_delete(socket, identity_id) do
     case find_account(socket, identity_id) do

--- a/lib/codex_pooler_web/live/admin/read_models/upstream_accounts_read_model/quota_projection.ex
+++ b/lib/codex_pooler_web/live/admin/read_models/upstream_accounts_read_model/quota_projection.ex
@@ -11,6 +11,7 @@ defmodule CodexPoolerWeb.Admin.UpstreamAccountsReadModel.QuotaProjection do
   @quota_priming_labels %{
     "unknown" => "Priming pending",
     "refreshing" => "Reconciling quota",
+    "confirmation_pending" => "Reset confirmation pending",
     "known" => "Quota known",
     "weekly_only_probe" => "Weekly-only probe",
     "stale" => "Quota stale",
@@ -68,7 +69,7 @@ defmodule CodexPoolerWeb.Admin.UpstreamAccountsReadModel.QuotaProjection do
   @spec put_current_quota_priming(map(), map()) :: map()
   def put_current_quota_priming(assignment, quota_readiness) do
     case assignment_priming_status(assignment) do
-      status when status in ["failed", "blocked"] ->
+      status when status in ["failed", "blocked", "refreshing", "confirmation_pending"] ->
         put_quota_priming(assignment, status)
 
       _status ->

--- a/lib/codex_pooler_web/live/admin/read_models/upstream_cockpit_read_model.ex
+++ b/lib/codex_pooler_web/live/admin/read_models/upstream_cockpit_read_model.ex
@@ -103,6 +103,7 @@ defmodule CodexPoolerWeb.Admin.UpstreamCockpitReadModel do
           required(:pause) => action(),
           required(:reactivate) => action(),
           required(:refresh_token) => action(),
+          required(:reconcile_quota) => action(),
           required(:redeem_saved_reset) => action(),
           required(:replace_auth_json) => action(),
           required(:oauth_relink) => action(),
@@ -485,6 +486,11 @@ defmodule CodexPoolerWeb.Admin.UpstreamCockpitReadModel do
         action(
           status in ["active", "refresh_due", "refresh_failed"],
           "token refresh is unavailable"
+        ),
+      reconcile_quota:
+        action(
+          status in ["active", "refresh_due", "refresh_failed"],
+          "quota refresh is unavailable"
         ),
       redeem_saved_reset: redeem_saved_reset,
       replace_auth_json: action(recovery_eligible?, "credential replacement is not needed"),

--- a/test/codex_pooler/jobs/account_priming_jobs_test.exs
+++ b/test/codex_pooler/jobs/account_priming_jobs_test.exs
@@ -80,6 +80,48 @@ defmodule CodexPooler.Jobs.AccountPrimingJobsTest do
       assert QuotaWindows.usable_window?(window)
     end
 
+    test "manual quota refresh updates priming state for every assignment of the identity" do
+      future_reset = DateTime.add(DateTime.utc_now(), 900, :second)
+
+      upstream =
+        start_path_upstream(%{
+          "/backend-api/wham/usage" =>
+            {200,
+             %{
+               "rate_limit" => %{
+                 "primary_window" => %{
+                   "used_percent" => 25,
+                   "limit_window_seconds" => 18_000,
+                   "reset_at" => DateTime.to_iso8601(future_reset)
+                 }
+               }
+             }}
+        })
+
+      {pool, assignment, identity} = codex_assignment_fixture(upstream)
+      second_pool = pool_fixture(%{name: "Shared identity quota pool"})
+
+      assert {:ok, sibling_assignment} =
+               PoolAssignments.assign_pool_assignment(second_pool, identity)
+
+      assert {:ok, result} =
+               AccountReconciliation.run(pool.id, assignment.id, "admin_upstreams_live")
+
+      assert result.catalog.code == "catalog_sync_skipped"
+
+      primary_priming =
+        Repo.get!(PoolUpstreamAssignment, assignment.id).metadata["quota_priming"]
+
+      sibling_priming =
+        Repo.get!(PoolUpstreamAssignment, sibling_assignment.id).metadata["quota_priming"]
+
+      assert primary_priming["status"] == "known"
+      assert sibling_priming == primary_priming
+
+      assert [usage_request] = FakeUpstream.requests(upstream)
+      assert usage_request.path == "/backend-api/wham/usage"
+    end
+
     test "account reconciliation refreshes an expired access token before quota priming" do
       future_reset = DateTime.add(DateTime.utc_now(), 900, :second)
       refresh_token = "refresh-token-#{System.unique_integer([:positive])}"

--- a/test/codex_pooler/jobs/account_quota_confirmation_worker_test.exs
+++ b/test/codex_pooler/jobs/account_quota_confirmation_worker_test.exs
@@ -1,0 +1,283 @@
+defmodule CodexPooler.Jobs.AccountQuotaConfirmationWorkerTest do
+  use CodexPooler.DataCase, async: false
+
+  import Ecto.Query
+  import CodexPooler.PoolerFixtures
+
+  alias CodexPooler.FakeUpstream
+  alias CodexPooler.Jobs.{AccountQuotaConfirmationWorker, AccountReconciliationWorker}
+  alias CodexPooler.Jobs.UpstreamEnqueue
+  alias CodexPooler.Repo
+  alias CodexPooler.Upstreams.Quota.Windows
+  alias CodexPooler.Upstreams.Quota.Windows.EvidenceStore
+  alias CodexPooler.Upstreams.Schemas.PoolUpstreamAssignment
+
+  @weekly_seconds 604_800
+
+  setup do
+    Repo.delete_all(Oban.Job)
+    :ok
+  end
+
+  test "manual refresh schedules and runs its own delayed zero confirmation" do
+    now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+    provider_reset_at = DateTime.add(now, @weekly_seconds, :second)
+
+    upstream = start_usage_upstream(0, provider_reset_at)
+
+    %{identity: identity, assignment: assignment} = assignment_fixture(upstream)
+    Repo.delete_all(Oban.Job)
+
+    assert {:ok, _row} =
+             Windows.record_evidence(
+               identity,
+               weekly_evidence(31, DateTime.add(now, -10, :minute), DateTime.add(now, 5, :day)),
+               DateTime.add(now, -10, :minute)
+             )
+
+    assert :ok =
+             perform_job(AccountReconciliationWorker, %{
+               "pool_id" => assignment.pool_id,
+               "pool_upstream_assignment_id" => assignment.id,
+               "upstream_identity_id" => identity.id,
+               "trigger_kind" => "admin_upstreams_live"
+             })
+
+    row = usage_row(identity)
+    assert Decimal.equal?(row.used_percent, Decimal.new(31))
+    assert {:ok, candidate} = EvidenceStore.parse_candidate(row.metadata)
+
+    priming = Repo.get!(PoolUpstreamAssignment, assignment.id).metadata["quota_priming"]
+    assert priming["status"] == "confirmation_pending"
+    assert priming["confirmation_pending_count"] == 1
+    assert is_binary(priming["confirmation_due_at"])
+
+    assert [confirmation_job] = all_enqueued(worker: AccountQuotaConfirmationWorker)
+    assert confirmation_job.state == "scheduled"
+    assert confirmation_job.args["upstream_identity_id"] == identity.id
+    assert confirmation_job.args["trigger_kind"] == "admin_quota_confirmation"
+
+    assert DateTime.diff(confirmation_job.scheduled_at, candidate.observed_at, :second) >=
+             EvidenceStore.weekly_restart_confirmation_span_seconds()
+
+    assert {:ok, duplicate_confirmation} =
+             AccountQuotaConfirmationWorker.enqueue_if_pending(
+               %{identity: identity, assignment: assignment},
+               "admin_upstreams_live"
+             )
+
+    assert duplicate_confirmation.conflict?
+    assert duplicate_confirmation.id == confirmation_job.id
+    assert [_one_confirmation] = all_enqueued(worker: AccountQuotaConfirmationWorker)
+
+    assert {:snooze, remaining_seconds} =
+             AccountQuotaConfirmationWorker.perform(%Oban.Job{args: confirmation_job.args})
+
+    assert remaining_seconds > 0
+
+    candidate_at = DateTime.add(DateTime.utc_now(), -4, :minute)
+
+    candidate_metadata = %{
+      "version" => 1,
+      "used_percent" => "0",
+      "reset_at" =>
+        candidate_at |> DateTime.add(@weekly_seconds, :second) |> DateTime.to_iso8601(),
+      "observed_at" => DateTime.to_iso8601(candidate_at),
+      "count" => 1
+    }
+
+    row
+    |> Ecto.Changeset.change(%{
+      metadata: Map.put(row.metadata, "__quota_confirmed_candidate_v1", candidate_metadata)
+    })
+    |> Repo.update!()
+
+    assert {:ok, recent_reconciliation} =
+             UpstreamEnqueue.enqueue_identity_account_reconciliation(
+               assignment.pool_id,
+               assignment,
+               trigger_kind: "scheduled"
+             )
+
+    recent_reconciliation
+    |> Ecto.Changeset.change(%{
+      state: "completed",
+      attempted_at: DateTime.utc_now(),
+      completed_at: DateTime.utc_now()
+    })
+    |> Repo.update!()
+
+    assert :ok = perform_job(AccountQuotaConfirmationWorker, confirmation_job.args)
+
+    assert [reconciliation_job] = all_enqueued(worker: AccountReconciliationWorker)
+    refute reconciliation_job.id == recent_reconciliation.id
+    assert reconciliation_job.args["trigger_kind"] == "admin_quota_confirmation"
+
+    assert %{success: 1, failure: 0} = Oban.drain_queue(queue: :jobs)
+
+    confirmed = usage_row(identity)
+    assert Decimal.equal?(confirmed.used_percent, Decimal.new(0))
+    assert EvidenceStore.parse_candidate(confirmed.metadata) == :none
+
+    priming = Repo.get!(PoolUpstreamAssignment, assignment.id).metadata["quota_priming"]
+    assert priming["status"] == "weekly_only_probe"
+    assert priming["confirmation_pending_count"] == 0
+
+    assert Enum.map(FakeUpstream.requests(upstream), & &1.path) == [
+             "/backend-api/wham/usage",
+             "/backend-api/codex/usage",
+             "/backend-api/wham/usage",
+             "/backend-api/codex/usage"
+           ]
+  end
+
+  test "manual refresh does not schedule confirmation without a pending zero" do
+    now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+    upstream = start_usage_upstream(43, DateTime.add(now, 5, :day))
+    %{identity: identity, assignment: assignment} = assignment_fixture(upstream)
+    Repo.delete_all(Oban.Job)
+
+    assert :ok =
+             perform_job(AccountReconciliationWorker, %{
+               "pool_id" => assignment.pool_id,
+               "pool_upstream_assignment_id" => assignment.id,
+               "upstream_identity_id" => identity.id,
+               "trigger_kind" => "admin_upstream_cockpit_live"
+             })
+
+    assert Decimal.equal?(usage_row(identity).used_percent, Decimal.new(43))
+    assert [] = all_enqueued(worker: AccountQuotaConfirmationWorker)
+
+    assert Enum.map(FakeUpstream.requests(upstream), & &1.path) == [
+             "/backend-api/wham/usage",
+             "/backend-api/codex/usage"
+           ]
+  end
+
+  test "delayed worker exits without another provider call after the candidate is resolved" do
+    now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+    upstream = start_usage_upstream(0, DateTime.add(now, @weekly_seconds, :second))
+    %{identity: identity, assignment: assignment} = assignment_fixture(upstream)
+
+    assert :ok =
+             perform_job(AccountQuotaConfirmationWorker, %{
+               "pool_id" => assignment.pool_id,
+               "pool_upstream_assignment_id" => assignment.id,
+               "upstream_identity_id" => identity.id,
+               "trigger_kind" => "admin_quota_confirmation"
+             })
+
+    assert FakeUpstream.requests(upstream) == []
+  end
+
+  test "confirmation bypasses the normal successful reconciliation cooldown" do
+    now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+    upstream = start_usage_upstream(0, DateTime.add(now, @weekly_seconds, :second))
+    %{identity: identity, assignment: assignment} = assignment_fixture(upstream)
+    Repo.delete_all(Oban.Job)
+
+    assert {:ok, _row} =
+             Windows.record_evidence(
+               identity,
+               weekly_evidence(31, DateTime.add(now, -10, :minute), DateTime.add(now, 5, :day)),
+               DateTime.add(now, -10, :minute)
+             )
+
+    candidate_at = DateTime.add(now, -4, :minute)
+
+    assert {:ok, _row} =
+             Windows.record_evidence(
+               identity,
+               weekly_evidence(
+                 0,
+                 candidate_at,
+                 DateTime.add(candidate_at, @weekly_seconds, :second)
+               ),
+               candidate_at
+             )
+
+    assert {:ok, cooldown_job} =
+             UpstreamEnqueue.enqueue_identity_account_reconciliation(
+               assignment.pool_id,
+               assignment,
+               trigger_kind: "scheduled"
+             )
+
+    {1, _rows} =
+      from(job in Oban.Job, where: job.id == ^cooldown_job.id)
+      |> Repo.update_all(set: [state: "completed", attempted_at: now, completed_at: now])
+
+    assert :ok =
+             perform_job(AccountQuotaConfirmationWorker, %{
+               "pool_id" => assignment.pool_id,
+               "pool_upstream_assignment_id" => assignment.id,
+               "upstream_identity_id" => identity.id,
+               "trigger_kind" => "admin_quota_confirmation"
+             })
+
+    worker = Oban.Worker.to_string(AccountReconciliationWorker)
+    account_jobs = Repo.all(from job in Oban.Job, where: job.worker == ^worker)
+    assert Enum.map(account_jobs, & &1.state) |> Enum.sort() == ["available", "completed"]
+
+    assert Enum.any?(account_jobs, fn job ->
+             job.id != cooldown_job.id and
+               job.args["trigger_kind"] == "admin_quota_confirmation"
+           end)
+  end
+
+  defp assignment_fixture(upstream) do
+    active_upstream_assignment_fixture(pool_fixture(), %{
+      metadata: %{
+        "base_url" => FakeUpstream.url(upstream),
+        "access_token_expires_at" =>
+          DateTime.utc_now() |> DateTime.add(10, :day) |> DateTime.to_iso8601()
+      }
+    })
+  end
+
+  defp weekly_evidence(used_percent, observed_at, reset_at) do
+    %{
+      quota_key: "account",
+      quota_scope: "account",
+      quota_family: "account",
+      window_kind: "secondary",
+      window_minutes: 10_080,
+      used_percent: Decimal.new(used_percent),
+      reset_at: reset_at,
+      observed_at: observed_at,
+      last_sync_at: observed_at,
+      source: "codex_usage_api",
+      source_precision: "observed",
+      freshness_state: "fresh"
+    }
+  end
+
+  defp usage_row(identity) do
+    identity
+    |> Windows.list_evidence()
+    |> Enum.find(&(&1.source == "codex_usage_api" and &1.window_kind == "secondary"))
+  end
+
+  defp start_usage_upstream(used_percent, reset_at) do
+    {:ok, upstream} =
+      FakeUpstream.start_link(
+        {:path_json,
+         %{
+           "/backend-api/wham/usage" =>
+             {200,
+              %{
+                "rate_limit" => %{
+                  "primary_window" => %{
+                    "used_percent" => used_percent,
+                    "limit_window_seconds" => @weekly_seconds,
+                    "reset_at" => DateTime.to_iso8601(reset_at)
+                  }
+                }
+              }}
+         }}
+      )
+
+    on_exit(fn -> FakeUpstream.stop(upstream) end)
+    upstream
+  end
+end

--- a/test/codex_pooler/upstreams/quota/windows/evidence_store_weekly_restart_test.exs
+++ b/test/codex_pooler/upstreams/quota/windows/evidence_store_weekly_restart_test.exs
@@ -3,6 +3,7 @@ defmodule CodexPooler.Upstreams.Quota.Windows.EvidenceStoreWeeklyRestartTest do
 
   import CodexPooler.PoolerFixtures
 
+  alias CodexPooler.Quotas.Evidence
   alias CodexPooler.Repo
   alias CodexPooler.Upstreams.Quota.AccountQuotaWindow
   alias CodexPooler.Upstreams.Quota.Windows
@@ -21,7 +22,7 @@ defmodule CodexPooler.Upstreams.Quota.Windows.EvidenceStoreWeeklyRestartTest do
     identity
   end
 
-  defp exhausted_row!(identity, observed_at, opts \\ []) do
+  defp usage_row!(identity, observed_at, used_percent, opts \\ []) do
     reset_at = Keyword.get(opts, :reset_at, DateTime.add(observed_at, 5, :day))
 
     Windows.record_evidence(
@@ -30,7 +31,7 @@ defmodule CodexPooler.Upstreams.Quota.Windows.EvidenceStoreWeeklyRestartTest do
         quota_key: "account",
         window_kind: "secondary",
         window_minutes: 10_080,
-        used_percent: Decimal.new("100"),
+        used_percent: Decimal.new(to_string(used_percent)),
         reset_at: reset_at,
         observed_at: observed_at,
         last_sync_at: observed_at,
@@ -43,6 +44,9 @@ defmodule CodexPooler.Upstreams.Quota.Windows.EvidenceStoreWeeklyRestartTest do
       observed_at
     )
   end
+
+  defp exhausted_row!(identity, observed_at, opts \\ []),
+    do: usage_row!(identity, observed_at, 100, opts)
 
   defp floating_zero(observed_at, opts \\ []) do
     reset_at = Keyword.get(opts, :reset_at, DateTime.add(observed_at, @window_seconds, :second))
@@ -207,23 +211,122 @@ defmodule CodexPooler.Upstreams.Quota.Windows.EvidenceStoreWeeklyRestartTest do
     assert DateTime.compare(row.reset_at, forward_anchor) == :eq
   end
 
-  test "a non-exhausted row is untouched by the restart path" do
+  test "sliding live zeroes converge a non-exhausted weekly account" do
     t0 = DateTime.utc_now() |> DateTime.add(-10, :minute) |> DateTime.truncate(:microsecond)
     identity = identity!()
+    assert {:ok, _row} = usage_row!(identity, t0, 31)
 
-    assert {:ok, _row} =
-             Windows.record_evidence(
-               identity,
-               Map.put(floating_zero(t0), :used_percent, Decimal.new("40")),
-               t0
-             )
-
+    # The first provider zero starts confirmation without immediately lowering
+    # a still-usable canonical row.
     t1 = DateTime.add(t0, 300, :second)
     assert {:ok, _row} = Windows.record_evidence(identity, floating_zero(t1), t1)
+    assert Decimal.compare(account_row(identity).used_percent, Decimal.new("31")) == :eq
 
-    # Pre-existing semantics for non-exhausted rows apply; nothing crashes and
-    # the row still exists with a valid percent.
+    # Repeated live evidence inside the confirmation span keeps waiting.
+    t2 = DateTime.add(t1, 60, :second)
+    assert {:ok, _row} = Windows.record_evidence(identity, floating_zero(t2), t2)
+    assert Decimal.compare(account_row(identity).used_percent, Decimal.new("31")) == :eq
+
+    # Once the floating reset advances with observations across the span, the
+    # same transition that production reported converges to 0% used.
+    t3 = DateTime.add(t1, 240, :second)
+    assert {:ok, _row} = Windows.record_evidence(identity, floating_zero(t3), t3)
+
     row = account_row(identity)
-    assert row
+    assert Decimal.compare(row.used_percent, Decimal.new("0")) == :eq
+    assert DateTime.compare(row.observed_at, t3) == :eq
+  end
+
+  test "repeated cached zeroes cannot lower a non-exhausted weekly account" do
+    t0 = DateTime.utc_now() |> DateTime.add(-20, :minute) |> DateTime.truncate(:microsecond)
+    identity = identity!()
+    fixed_reset = DateTime.add(t0, 5, :day)
+    assert {:ok, _row} = usage_row!(identity, t0, 31, reset_at: fixed_reset)
+
+    for minute <- 1..16 do
+      observed_at = DateTime.add(t0, minute, :minute)
+
+      assert {:ok, _row} =
+               Windows.record_evidence(
+                 identity,
+                 floating_zero(observed_at, reset_at: fixed_reset),
+                 observed_at
+               )
+    end
+
+    row = account_row(identity)
+    assert Decimal.compare(row.used_percent, Decimal.new("31")) == :eq
+    assert DateTime.compare(row.observed_at, t0) == :eq
+  end
+
+  test "repeated live zeroes keep an accepted weekly reset fresh beyond the ttl" do
+    t0 = DateTime.utc_now() |> DateTime.add(-20, :minute) |> DateTime.truncate(:microsecond)
+    identity = identity!()
+    assert {:ok, _row} = Windows.record_evidence(identity, floating_zero(t0), t0)
+
+    for minute <- 1..16 do
+      observed_at = DateTime.add(t0, minute, :minute)
+
+      assert {:ok, _row} =
+               Windows.record_evidence(identity, floating_zero(observed_at), observed_at)
+
+      assert Evidence.current_freshness_state(account_row(identity), observed_at) == "fresh"
+    end
+
+    row = account_row(identity)
+    assert Decimal.compare(row.used_percent, Decimal.new("0")) == :eq
+    assert DateTime.diff(row.observed_at, t0, :minute) >= 12
+  end
+
+  test "live zeroes recover an already stale accepted weekly reset" do
+    t0 = DateTime.utc_now() |> DateTime.add(-30, :minute) |> DateTime.truncate(:microsecond)
+    identity = identity!()
+    assert {:ok, _row} = Windows.record_evidence(identity, floating_zero(t0), t0)
+
+    stale_at = DateTime.add(t0, 16, :minute)
+    assert Evidence.current_freshness_state(account_row(identity), stale_at) == "stale"
+
+    # The first live response starts a new confirmation without trusting one
+    # weak zero enough to refresh routing immediately.
+    assert {:ok, _row} =
+             Windows.record_evidence(identity, floating_zero(stale_at), stale_at)
+
+    assert DateTime.compare(account_row(identity).observed_at, t0) == :eq
+
+    # A later response whose reset advanced with wall time proves the endpoint
+    # is live and makes the already-zero canonical usable again.
+    confirmed_at = DateTime.add(stale_at, 4, :minute)
+
+    assert {:ok, _row} =
+             Windows.record_evidence(identity, floating_zero(confirmed_at), confirmed_at)
+
+    row = account_row(identity)
+    assert Decimal.compare(row.used_percent, Decimal.new("0")) == :eq
+    assert DateTime.compare(row.observed_at, confirmed_at) == :eq
+    assert Evidence.current_freshness_state(row, confirmed_at) == "fresh"
+  end
+
+  test "repeated cached zeroes cannot keep an accepted weekly reset fresh" do
+    t0 = DateTime.utc_now() |> DateTime.add(-20, :minute) |> DateTime.truncate(:microsecond)
+    identity = identity!()
+    fixed_reset = DateTime.add(t0, @window_seconds, :second)
+
+    assert {:ok, _row} =
+             Windows.record_evidence(identity, floating_zero(t0, reset_at: fixed_reset), t0)
+
+    for minute <- 1..16 do
+      observed_at = DateTime.add(t0, minute, :minute)
+
+      assert {:ok, _row} =
+               Windows.record_evidence(
+                 identity,
+                 floating_zero(observed_at, reset_at: fixed_reset),
+                 observed_at
+               )
+    end
+
+    row = account_row(identity)
+    assert DateTime.compare(row.observed_at, t0) == :eq
+    assert Evidence.current_freshness_state(row, DateTime.add(t0, 16, :minute)) == "stale"
   end
 end

--- a/test/codex_pooler/upstreams/quota_reconciliation_enqueue_test.exs
+++ b/test/codex_pooler/upstreams/quota_reconciliation_enqueue_test.exs
@@ -1,0 +1,131 @@
+defmodule CodexPooler.Upstreams.QuotaReconciliationEnqueueTest do
+  use CodexPooler.DataCase, async: false
+
+  import CodexPooler.AccountsFixtures
+  import CodexPooler.PoolerFixtures
+
+  alias CodexPooler.Accounts.Scope
+  alias CodexPooler.Audit.AuditEvent
+  alias CodexPooler.Jobs.AccountReconciliationWorker
+  alias CodexPooler.Jobs.UpstreamEnqueue
+  alias CodexPooler.Repo
+  alias CodexPooler.Upstreams
+  alias CodexPooler.Upstreams.Assignments.PoolAssignments
+
+  setup do
+    Repo.delete_all(Oban.Job)
+    :ok
+  end
+
+  test "queues one reconciliation for a shared identity and audits every affected pool" do
+    scope = owner_scope()
+    first_pool = pool_fixture(%{name: "First quota pool"})
+    second_pool = pool_fixture(%{name: "Second quota pool"})
+
+    %{identity: identity, assignment: first_assignment} =
+      active_upstream_assignment_fixture(first_pool)
+
+    assert {:ok, second_assignment} =
+             PoolAssignments.assign_pool_assignment(second_pool, identity)
+
+    assert {:ok, second_assignment} =
+             PoolAssignments.update_pool_assignment(second_assignment, %{status: "paused"})
+
+    Repo.delete_all(Oban.Job)
+
+    assert {:ok, %{status: :queued, job: job, assignments: assignments}} =
+             Upstreams.enqueue_quota_reconciliation_for_scope(
+               scope,
+               identity,
+               trigger_kind: "admin_upstreams_live"
+             )
+
+    assert Enum.map(assignments, & &1.id) == [first_assignment.id, second_assignment.id]
+    assert Enum.map(assignments, & &1.status) == ["active", "paused"]
+    assert job.worker == Oban.Worker.to_string(AccountReconciliationWorker)
+    assert job.args["pool_id"] == first_pool.id
+    assert job.args["pool_upstream_assignment_id"] == first_assignment.id
+    assert job.args["upstream_identity_id"] == identity.id
+    assert job.args["target_kind"] == "upstream_identity"
+    assert job.args["trigger_kind"] == "admin_upstreams_live"
+
+    assert [persisted_job] = all_enqueued(worker: AccountReconciliationWorker)
+    assert persisted_job.id == job.id
+
+    audit_pool_ids =
+      Repo.all(
+        from event in AuditEvent,
+          where: event.action == "upstream_account.quota_reconciliation_enqueue",
+          where: event.target_id == ^identity.id,
+          select: event.pool_id
+      )
+
+    assert MapSet.new(audit_pool_ids) == MapSet.new([first_pool.id, second_pool.id])
+  end
+
+  test "reports a duplicate identity reconciliation without inserting another job" do
+    scope = owner_scope()
+    pool = pool_fixture()
+    %{identity: identity} = active_upstream_assignment_fixture(pool)
+    Repo.delete_all(Oban.Job)
+
+    assert {:ok, %{status: :queued, job: first_job}} =
+             Upstreams.enqueue_quota_reconciliation_for_scope(scope, identity)
+
+    assert {:ok, %{status: :already_queued, job: second_job}} =
+             Upstreams.enqueue_quota_reconciliation_for_scope(scope, identity)
+
+    assert first_job.id == second_job.id
+    assert Repo.aggregate(Oban.Job, :count) == 1
+  end
+
+  test "deduplicates against an automatic job queued through another pool assignment" do
+    scope = owner_scope()
+    first_pool = pool_fixture(%{name: "First automatic pool"})
+    second_pool = pool_fixture(%{name: "Second automatic pool"})
+    %{identity: identity} = active_upstream_assignment_fixture(first_pool)
+
+    assert {:ok, second_assignment} =
+             PoolAssignments.assign_pool_assignment(second_pool, identity)
+
+    Repo.delete_all(Oban.Job)
+
+    assert {:ok, automatic_job} =
+             UpstreamEnqueue.enqueue_scheduled_identity_account_reconciliation(second_assignment)
+
+    assert {:ok, %{status: :already_queued, job: manual_job}} =
+             Upstreams.enqueue_quota_reconciliation_for_scope(scope, identity)
+
+    assert manual_job.id == automatic_job.id
+    assert manual_job.args["pool_upstream_assignment_id"] == second_assignment.id
+    assert Repo.aggregate(Oban.Job, :count) == 1
+  end
+
+  test "rejects identities without a reconcilable assignment" do
+    scope = owner_scope()
+    pool = pool_fixture()
+    %{identity: identity, assignment: assignment} = active_upstream_assignment_fixture(pool)
+
+    assert {:ok, _assignment} =
+             PoolAssignments.update_pool_assignment(assignment, %{status: "paused"})
+
+    Repo.delete_all(Oban.Job)
+
+    assert {:error, %{code: :quota_reconciliation_unavailable}} =
+             Upstreams.enqueue_quota_reconciliation_for_scope(scope, identity)
+
+    assert Repo.aggregate(Oban.Job, :count) == 0
+  end
+
+  test "rejects an invalid user scope" do
+    identity = active_upstream_identity_fixture()
+
+    assert {:error, %{code: :invalid_request}} =
+             Upstreams.enqueue_quota_reconciliation_for_scope(nil, identity)
+  end
+
+  defp owner_scope do
+    %{user: user} = bootstrap_owner_fixture(%{"email" => unique_user_email()})
+    Scope.for_user(user, ["instance_owner"])
+  end
+end

--- a/test/codex_pooler_web/live/admin/pages/upstream_cockpit_live_test.exs
+++ b/test/codex_pooler_web/live/admin/pages/upstream_cockpit_live_test.exs
@@ -8,7 +8,13 @@ defmodule CodexPoolerWeb.Admin.UpstreamCockpitLiveTest do
   alias CodexPooler.Audit
   alias CodexPooler.Events
   alias CodexPooler.FakeOpenAIAuthProvider
-  alias CodexPooler.Jobs.SavedResetRedemptionWorker
+
+  alias CodexPooler.Jobs.{
+    AccountReconciliationWorker,
+    SavedResetRedemptionWorker,
+    TokenRefreshWorker
+  }
+
   alias CodexPooler.Pools
   alias CodexPooler.Quotas.Evidence
   alias CodexPooler.Repo
@@ -3456,12 +3462,34 @@ defmodule CodexPoolerWeb.Admin.UpstreamCockpitLiveTest do
 
     assert has_element?(
              view,
+             "#cockpit-reconcile-upstream-account-#{identity.id}",
+             "Refresh quota"
+           )
+
+    assert has_element?(
+             view,
              "#cockpit-replace-auth-json-upstream-account-#{identity.id}",
              "Replace auth.json"
            )
 
     assert has_element?(view, "#cockpit-delete-upstream-account-#{identity.id}", "Delete")
     assert has_element?(view, "#cockpit-reactivate-upstream-account-#{identity.id}", "Reactivate")
+
+    view |> element("#cockpit-reconcile-upstream-account-#{identity.id}") |> render_click()
+
+    assert render(view) =~
+             "Quota refresh queued; reset changes, if detected, are confirmed automatically after about 3 minutes"
+
+    assert %Oban.Job{} =
+             reconcile_job =
+             Repo.all(Oban.Job)
+             |> Enum.find(fn j ->
+               j.worker == worker_name(AccountReconciliationWorker) and
+                 j.args["trigger_kind"] == "admin_upstream_cockpit_live" and
+                 j.args["pool_id"] == pool.id
+             end)
+
+    assert is_binary(reconcile_job.args["pool_upstream_assignment_id"])
 
     assert has_element?(
              view,
@@ -3518,9 +3546,12 @@ defmodule CodexPoolerWeb.Admin.UpstreamCockpitLiveTest do
     assert %Oban.Job{} =
              job =
              Repo.all(Oban.Job)
-             |> Enum.find(&(&1.args["trigger_kind"] == "admin_upstream_cockpit_live"))
+             |> Enum.find(fn j ->
+               j.worker == worker_name(TokenRefreshWorker) and
+                 j.args["upstream_identity_id"] == identity.id
+             end)
 
-    assert job.args["upstream_identity_id"] == identity.id
+    assert job.args["trigger_kind"] == "admin_upstream_cockpit_live"
 
     rendered_before_delete = render(view)
 

--- a/test/codex_pooler_web/live/admin/pages/upstreams_live_test.exs
+++ b/test/codex_pooler_web/live/admin/pages/upstreams_live_test.exs
@@ -13,6 +13,7 @@ defmodule CodexPoolerWeb.Admin.UpstreamsLiveTest do
   alias CodexPooler.Events.Event
   alias CodexPooler.Events.PostgresBridge
   alias CodexPooler.FakeOpenAIAuthProvider
+  alias CodexPooler.Jobs.AccountReconciliationWorker
   alias CodexPooler.Jobs.SavedResetRedemptionWorker
   alias CodexPooler.Jobs.TokenRefreshWorker
   alias CodexPooler.Mailer
@@ -2031,6 +2032,41 @@ defmodule CodexPoolerWeb.Admin.UpstreamsLiveTest do
     refute has_element?(view, "#upstream-account-#{deleted_identity.id}")
   end
 
+  test "manually enqueues account reconciliation for an identity from the upstreams page", %{
+    conn: conn,
+    scope: scope
+  } do
+    {:ok, pool} = Pools.create_pool(scope, %{slug: "manual-reconcile", name: "Manual Reconcile"})
+
+    %{identity: identity, assignment: assignment} =
+      active_upstream_assignment_fixture(pool, %{
+        account_label: "Manual Reconcile Codex"
+      })
+
+    {:ok, view, _html} = live(conn, ~p"/admin/upstreams")
+
+    assert has_element?(view, "#reconcile-upstream-account-#{identity.id}")
+
+    # Trigger reconcile
+    view
+    |> element("#reconcile-upstream-account-#{identity.id}")
+    |> render_click()
+
+    assert render(view) =~
+             "Quota refresh queued; reset changes, if detected, are confirmed automatically after about 3 minutes"
+
+    assert %Oban.Job{} =
+             job =
+             Repo.all(Oban.Job)
+             |> Enum.find(fn j ->
+               j.worker == worker_name(AccountReconciliationWorker) and
+                 j.args["trigger_kind"] == "admin_upstreams_live" and
+                 j.args["pool_upstream_assignment_id"] == assignment.id
+             end)
+
+    assert job.args["pool_id"] == pool.id
+  end
+
   @tag :upstream_filters
   test "malformed nested URL params normalize to default filters without crashing", %{
     conn: conn,
@@ -3326,6 +3362,7 @@ defmodule CodexPoolerWeb.Admin.UpstreamsLiveTest do
     cases = [
       {"unknown", "Quota missing", "Quota missing", "Priming pending"},
       {"refreshing", "Quota missing", "Quota missing", "Reconciling quota"},
+      {"confirmation_pending", "Quota missing", "Quota missing", "Reset confirmation pending"},
       {"known", "Routing ready", "Quota ready", "Quota known"},
       {"weekly_only_probe", "Routing ready", "Weekly quota probe", "Weekly-only probe"},
       {"stale", "Quota missing", "Quota missing", "Quota stale"},
@@ -6173,7 +6210,7 @@ defmodule CodexPoolerWeb.Admin.UpstreamsLiveTest do
 
   defp worker_name(worker), do: worker |> Atom.to_string() |> String.replace_prefix("Elixir.", "")
 
-  defp assert_single_element(view, selector, text \\ nil) do
+  defp assert_single_element(view, selector, text) do
     rendered = view |> element(selector, text) |> render()
     assert rendered != ""
   end

--- a/test/codex_pooler_web/live/admin/read_models/upstream_accounts_read_model/quota_projection_test.exs
+++ b/test/codex_pooler_web/live/admin/read_models/upstream_accounts_read_model/quota_projection_test.exs
@@ -230,6 +230,17 @@ defmodule CodexPoolerWeb.Admin.UpstreamAccountsReadModel.QuotaProjectionTest do
     end
   end
 
+  test "pending reset confirmation overrides the old canonical quota readiness" do
+    assignment = %{
+      metadata: %{"quota_priming" => %{"status" => "confirmation_pending"}}
+    }
+
+    projected = QuotaProjection.put_current_quota_priming(assignment, %{state: "ready"})
+
+    assert projected.quota_priming_status == "confirmation_pending"
+    assert projected.quota_priming_label == "Reset confirmation pending"
+  end
+
   test "later persisted successful priming overrides an earlier terminal state" do
     assignment = %{metadata: %{"quota_priming" => %{"status" => "known"}}}
 


### PR DESCRIPTION
## Summary

- Make admin quota refresh identity-scoped and fan the resulting priming state out to every pool assignment linked to that upstream identity.
- Quarantine reset-shaped weekly zero observations instead of immediately replacing a previously non-zero usage projection.
- Schedule an identity-deduplicated confirmation probe after the three-minute safety span so a manual refresh completes its own reset reconciliation instead of waiting for the normal scheduler.
- Surface `confirmation_pending` in the admin UI with explicit operator feedback while the second observation is pending.
- Keep cached or replayed fixed-reset responses from indefinitely restoring stale usage evidence as fresh.

## Problem

The provider can return a reset-shaped `0% used` observation immediately after a weekly quota reset. The evidence layer correctly holds that first zero as a candidate to protect an existing non-zero row from a stale or replayed response. However, a manual **Refresh quota** job stopped after that first observation. The UI therefore continued to show the old percentage until the periodic reconciliation scheduler happened to run again, making the successful manual action look like a no-op.

This was particularly visible when ChatGPT/Codex showed the account reset to 100% available while codex-pooler continued to display the previous usage percentage. In some cases, cached usage responses could also make the displayed state appear to move backward.

## Implementation

### Reset evidence convergence

- Detect weekly reset candidates using the existing reset-anchor and freshness rules.
- Preserve the last trusted non-zero value on the first reset-shaped zero observation.
- Require an equivalent observation after the confirmation span before accepting the zero and advancing the reset anchor.
- Allow fixed-reset cached evidence to age stale instead of refreshing it indefinitely.

### Self-healing manual refresh

- Add `AccountQuotaConfirmationWorker`, scheduled only when an admin-triggered refresh leaves a pending weekly-zero candidate.
- Deduplicate confirmation jobs by upstream identity.
- Re-check the candidate at execution time and exit without a provider call if another reconciliation already resolved it.
- Enqueue the canonical identity-scoped account reconciliation after the safety span.
- Bypass only the normal 60-second **successful-job** cooldown for the confirmation probe; the untimed incomplete-job guard and Oban uniqueness boundary still prevent overlapping work.
- Snooze when an older reconciliation is still executing, allowing that run to resolve the candidate before probing again.
- Skip catalog synchronization for the confirmation trigger so the follow-up performs only the quota usage probes.
- Avoid recursive confirmation scheduling: confirmation-triggered reconciliation never creates another delayed confirmation worker.

### Operator visibility

- Persist `confirmation_pending_count` and `confirmation_due_at` in quota priming metadata.
- Display **Reset confirmation pending** in upstream list and cockpit views.
- Tell operators that reset changes are confirmed automatically after about three minutes.

## Race and recovery behavior

- At most one incomplete account reconciliation exists per upstream identity.
- At most one incomplete delayed confirmation exists per upstream identity.
- A recent completed reconciliation cannot suppress the due confirmation probe.
- An already-resolved candidate produces no extra provider request.
- Transient failures remain covered by the canonical account reconciliation worker retry path and the normal reconciliation scheduler.
- Multiple pool assignments for the same identity receive the same priming result.

## Verification

- Dedicated confirmation-worker regression suite: **4 passed**.
- Reconciliation, priming, reset-evidence, enqueue, projection, routing, and readiness suites: **163 passed**.
- Full upstream list and upstream cockpit LiveView suites: **128 passed**.
- Patch whitespace validation: `git diff --check` passed.

Coverage includes:

- first zero creates a pending candidate without lowering the trusted usage row;
- duplicate confirmation enqueue is deduplicated;
- early execution snoozes until the evidence span has elapsed;
- due confirmation bypasses the recent-success cooldown without bypassing overlap protection;
- the second provider observation confirms the reset and clears the candidate;
- non-zero refreshes do not schedule confirmation work;
- already-resolved candidates cause no provider call;
- UI status and flash messaging reflect the pending confirmation.

## Deployment notes

- No database migration is required.
- No one-off database cleanup is required.
- Standard application deployment is sufficient.
- After deployment, an admin quota refresh that detects a reset will show a pending state and reconcile automatically after approximately three minutes.