### PR TITLE
fix(streaming): normalize accumulated tool-call argument chunks

### DIFF
--- a/lib/codex_pooler/gateway/openai_compatibility/chat_completions.ex
+++ b/lib/codex_pooler/gateway/openai_compatibility/chat_completions.ex
@@ -3,6 +3,7 @@ defmodule CodexPooler.Gateway.OpenAICompatibility.ChatCompletions do
 
   alias CodexPooler.Gateway.OpenAICompatibility.PublicResponse
   alias CodexPooler.Gateway.Runtime.Streaming.BufferTelemetry
+  alias CodexPooler.Gateway.Transports.Streaming.FunctionCallArguments
   alias CodexPooler.Gateway.Transports.Streaming.StreamProtocol
 
   @spec normalize_response(map(), map()) :: map()
@@ -33,7 +34,13 @@ defmodule CodexPooler.Gateway.OpenAICompatibility.ChatCompletions do
           required(:model) => String.t() | nil,
           required(:role_sent?) => boolean(),
           required(:include_usage?) => boolean(),
-          required(:discarding_oversized?) => boolean()
+          required(:discarding_oversized?) => boolean(),
+          required(:tool_calls) => %{
+            optional(non_neg_integer()) => %{
+              required(:introduced?) => boolean(),
+              required(:arguments) => binary()
+            }
+          }
         }
 
   @max_incomplete_chat_sse_block_bytes 1_048_576
@@ -122,15 +129,24 @@ defmodule CodexPooler.Gateway.OpenAICompatibility.ChatCompletions do
     text_delta_chunk(decoded_string(decoded, "delta") || "", state)
   end
 
-  defp normalize_stream_event(type, decoded, state)
-       when type in ["response.output_item.added", "response.output_item.done"] do
+  defp normalize_stream_event("response.output_item.added", decoded, state) do
     state = sync_response_state(state, decoded)
-    tool_call_item_chunk(decoded["item"], decoded, state)
+    tool_call_item_added_chunk(decoded["item"], decoded, state)
+  end
+
+  defp normalize_stream_event("response.output_item.done", decoded, state) do
+    state = sync_response_state(state, decoded)
+    tool_call_item_done_chunk(decoded["item"], decoded, state)
   end
 
   defp normalize_stream_event("response.function_call_arguments.delta", decoded, state) do
     state = sync_response_state(state, decoded)
     tool_call_arguments_chunk(decoded, state)
+  end
+
+  defp normalize_stream_event("response.function_call_arguments.done", decoded, state) do
+    state = sync_response_state(state, decoded)
+    tool_call_arguments_done_chunk(decoded, state)
   end
 
   defp normalize_stream_event(type, decoded, state) when is_binary(type) do
@@ -186,19 +202,81 @@ defmodule CodexPooler.Gateway.OpenAICompatibility.ChatCompletions do
   defp text_delta_chunk(delta, state),
     do: {chat_sse_chunk(%{"content" => delta}, nil, state), state}
 
-  defp tool_call_item_chunk(%{"type" => "function_call"} = item, context, state) do
+  defp tool_call_item_added_chunk(%{"type" => "function_call"} = item, context, state) do
+    index = tool_call_index(item, context)
+    arguments = decoded_string(item, "arguments") || ""
+
+    if tool_call_introduced?(state, index) do
+      reconcile_tool_call_arguments(arguments, index, state)
+    else
+      delta = %{
+        "tool_calls" => [
+          %{
+            "index" => index,
+            "id" => tool_call_id(item, context, index),
+            "type" => "function",
+            "function" => %{
+              "name" => decoded_string(item, "name") || "tool",
+              "arguments" => arguments
+            }
+          }
+        ]
+      }
+
+      state = put_tool_call(state, index, true, arguments)
+      {chat_sse_chunk(delta, nil, state), state}
+    end
+  end
+
+  defp tool_call_item_added_chunk(_item, _context, state), do: {[], state}
+
+  defp tool_call_item_done_chunk(%{"type" => "function_call"} = item, context, state) do
     index = tool_call_index(item, context)
 
+    if tool_call_introduced?(state, index) do
+      reconcile_tool_call_arguments(decoded_string(item, "arguments") || "", index, state)
+    else
+      tool_call_item_added_chunk(item, context, state)
+    end
+  end
+
+  defp tool_call_item_done_chunk(_item, _context, state), do: {[], state}
+
+  defp tool_call_arguments_chunk(decoded, state) do
+    index = Map.get(decoded, "output_index") || 0
+    incoming = decoded_string(decoded, "delta") || ""
+    previous = tool_call_arguments(state, index)
+    {delta_arguments, arguments} = FunctionCallArguments.normalize_delta(previous, incoming)
+    state = put_tool_call(state, index, tool_call_introduced?(state, index), arguments)
+
+    tool_call_arguments_delta_chunk(delta_arguments, index, state)
+  end
+
+  defp tool_call_arguments_done_chunk(decoded, state) do
+    index = Map.get(decoded, "output_index") || 0
+
+    reconcile_tool_call_arguments(
+      decoded_string(decoded, "arguments") || "",
+      index,
+      state
+    )
+  end
+
+  defp reconcile_tool_call_arguments(arguments, index, state) do
+    previous = tool_call_arguments(state, index)
+    {delta, reconciled} = FunctionCallArguments.reconcile_snapshot(previous, arguments)
+    state = put_tool_call(state, index, tool_call_introduced?(state, index), reconciled)
+    tool_call_arguments_delta_chunk(delta, index, state)
+  end
+
+  defp tool_call_arguments_delta_chunk("", _index, state), do: {[], state}
+
+  defp tool_call_arguments_delta_chunk(arguments, index, state) do
     delta = %{
       "tool_calls" => [
         %{
           "index" => index,
-          "id" => tool_call_id(item, context, index),
-          "type" => "function",
-          "function" => %{
-            "name" => decoded_string(item, "name") || "tool",
-            "arguments" => decoded_string(item, "arguments") || ""
-          }
+          "function" => %{"arguments" => arguments}
         }
       ]
     }
@@ -206,21 +284,17 @@ defmodule CodexPooler.Gateway.OpenAICompatibility.ChatCompletions do
     {chat_sse_chunk(delta, nil, state), state}
   end
 
-  defp tool_call_item_chunk(_item, _context, state), do: {[], state}
+  defp tool_call_introduced?(state, index) do
+    get_in(state, [:tool_calls, index, :introduced?]) == true
+  end
 
-  defp tool_call_arguments_chunk(decoded, state) do
-    index = Map.get(decoded, "output_index") || 0
+  defp tool_call_arguments(state, index) do
+    get_in(state, [:tool_calls, index, :arguments]) || ""
+  end
 
-    delta = %{
-      "tool_calls" => [
-        %{
-          "index" => index,
-          "function" => %{"arguments" => decoded_string(decoded, "delta") || ""}
-        }
-      ]
-    }
-
-    {chat_sse_chunk(delta, nil, state), state}
+  defp put_tool_call(state, index, introduced?, arguments) do
+    tool_call = %{introduced?: introduced?, arguments: arguments}
+    %{state | tool_calls: Map.put(state.tool_calls, index, tool_call)}
   end
 
   defp terminal_stream_chunk(type, decoded, %{role_sent?: false} = state)
@@ -286,7 +360,8 @@ defmodule CodexPooler.Gateway.OpenAICompatibility.ChatCompletions do
       model: Map.get(chat_payload, "model"),
       role_sent?: false,
       include_usage?: get_in(chat_payload, ["stream_options", "include_usage"]) == true,
-      discarding_oversized?: false
+      discarding_oversized?: false,
+      tool_calls: %{}
     }
   end
 

--- a/lib/codex_pooler/gateway/transports/streaming/function_call_arguments.ex
+++ b/lib/codex_pooler/gateway/transports/streaming/function_call_arguments.ex
@@ -1,0 +1,38 @@
+defmodule CodexPooler.Gateway.Transports.Streaming.FunctionCallArguments do
+  @moduledoc false
+
+  @spec normalize_delta(binary(), binary()) :: {binary(), binary()}
+  def normalize_delta(previous, "") when is_binary(previous), do: {"", previous}
+
+  def normalize_delta("", incoming) when is_binary(incoming), do: {incoming, incoming}
+
+  def normalize_delta(previous, incoming)
+      when is_binary(previous) and is_binary(incoming) do
+    if String.starts_with?(incoming, previous) do
+      delta =
+        binary_part(incoming, byte_size(previous), byte_size(incoming) - byte_size(previous))
+
+      {delta, incoming}
+    else
+      {incoming, previous <> incoming}
+    end
+  end
+
+  @spec reconcile_snapshot(binary(), binary()) :: {binary(), binary()}
+  def reconcile_snapshot(previous, snapshot)
+      when is_binary(previous) and is_binary(snapshot) do
+    cond do
+      snapshot == "" or snapshot == previous ->
+        {"", previous}
+
+      String.starts_with?(snapshot, previous) ->
+        delta =
+          binary_part(snapshot, byte_size(previous), byte_size(snapshot) - byte_size(previous))
+
+        {delta, snapshot}
+
+      true ->
+        {"", previous}
+    end
+  end
+end

--- a/lib/codex_pooler/gateway/transports/streaming/stream_protocol/public_responses.ex
+++ b/lib/codex_pooler/gateway/transports/streaming/stream_protocol/public_responses.ex
@@ -3,6 +3,7 @@ defmodule CodexPooler.Gateway.Transports.Streaming.StreamProtocol.PublicResponse
 
   alias CodexPooler.Gateway.OpenAICompatibility.PublicResponse
   alias CodexPooler.Gateway.Runtime.Streaming.BufferTelemetry
+  alias CodexPooler.Gateway.Transports.Streaming.FunctionCallArguments
   alias CodexPooler.Gateway.Transports.Streaming.StreamProtocol
 
   @type passthrough_terminal_state :: %{
@@ -49,7 +50,8 @@ defmodule CodexPooler.Gateway.Transports.Streaming.StreamProtocol.PublicResponse
           required(:passthrough_terminal) => passthrough_terminal_state() | nil,
           required(:passthrough_terminal_kind) => atom() | nil,
           required(:passthrough_terminal_failure) => StreamProtocol.terminal_failure() | nil,
-          required(:passthrough_terminal_seen?) => boolean()
+          required(:passthrough_terminal_seen?) => boolean(),
+          required(:function_call_arguments) => %{optional(term()) => binary()}
         }
 
   @spec new_state() :: state()
@@ -66,7 +68,8 @@ defmodule CodexPooler.Gateway.Transports.Streaming.StreamProtocol.PublicResponse
       passthrough_terminal: nil,
       passthrough_terminal_kind: nil,
       passthrough_terminal_failure: nil,
-      passthrough_terminal_seen?: false
+      passthrough_terminal_seen?: false,
+      function_call_arguments: %{}
     }
   end
 
@@ -459,6 +462,7 @@ defmodule CodexPooler.Gateway.Transports.Streaming.StreamProtocol.PublicResponse
     {type, decoded} = StreamProtocol.normalize_terminal_event(type, decoded)
     decoded = normalize_public_event(type, decoded)
     state = maybe_put_response_id(state, decoded)
+    {decoded, state} = normalize_function_call_arguments(type, decoded, state)
 
     normalize_public_block(type, decoded, state)
   end
@@ -577,6 +581,91 @@ defmodule CodexPooler.Gateway.Transports.Streaming.StreamProtocol.PublicResponse
     else
       decoded
     end
+  end
+
+  defp normalize_function_call_arguments("response.output_item.added", decoded, state),
+    do: seed_function_call_arguments(decoded, state)
+
+  defp normalize_function_call_arguments("response.output_item.done", decoded, state),
+    do: reconcile_function_call_arguments(decoded, state)
+
+  defp normalize_function_call_arguments(
+         "response.function_call_arguments.delta",
+         decoded,
+         state
+       ) do
+    case function_call_key(decoded) do
+      nil ->
+        {decoded, state}
+
+      key ->
+        previous = Map.get(state.function_call_arguments, key, "")
+        incoming = decoded_string(decoded, "delta") || ""
+        {delta, arguments} = FunctionCallArguments.normalize_delta(previous, incoming)
+
+        {
+          Map.put(decoded, "delta", delta),
+          put_function_call_arguments(state, key, arguments)
+        }
+    end
+  end
+
+  defp normalize_function_call_arguments(
+         "response.function_call_arguments.done",
+         decoded,
+         state
+       ),
+       do: reconcile_function_call_arguments(decoded, state)
+
+  defp normalize_function_call_arguments(_type, decoded, state), do: {decoded, state}
+
+  defp seed_function_call_arguments(decoded, state) do
+    with key when not is_nil(key) <- function_call_key(decoded),
+         arguments when is_binary(arguments) <- function_call_item_arguments(decoded) do
+      arguments_by_call = Map.put_new(state.function_call_arguments, key, arguments)
+      {decoded, %{state | function_call_arguments: arguments_by_call}}
+    else
+      _missing_function_call -> {decoded, state}
+    end
+  end
+
+  defp reconcile_function_call_arguments(decoded, state) do
+    with key when not is_nil(key) <- function_call_key(decoded),
+         arguments when is_binary(arguments) <- function_call_snapshot(decoded) do
+      previous = Map.get(state.function_call_arguments, key, "")
+      {_delta, reconciled} = FunctionCallArguments.reconcile_snapshot(previous, arguments)
+      {decoded, put_function_call_arguments(state, key, reconciled)}
+    else
+      _missing_function_call -> {decoded, state}
+    end
+  end
+
+  defp function_call_key(decoded) when is_map(decoded) do
+    case Map.fetch(decoded, "output_index") do
+      {:ok, index} -> {:output_index, index}
+      :error -> function_call_item_key(decoded)
+    end
+  end
+
+  defp function_call_key(_decoded), do: nil
+
+  defp function_call_item_key(decoded) do
+    item_id = Map.get(decoded, "item_id") || get_in(decoded, ["item", "id"])
+    if is_binary(item_id), do: {:item_id, item_id}, else: nil
+  end
+
+  defp function_call_item_arguments(%{"item" => %{"type" => "function_call"} = item}),
+    do: decoded_string(item, "arguments") || ""
+
+  defp function_call_item_arguments(_decoded), do: nil
+
+  defp function_call_snapshot(%{"arguments" => arguments}) when is_binary(arguments),
+    do: arguments
+
+  defp function_call_snapshot(decoded), do: function_call_item_arguments(decoded)
+
+  defp put_function_call_arguments(state, key, arguments) do
+    %{state | function_call_arguments: Map.put(state.function_call_arguments, key, arguments)}
   end
 
   defp normalize_terminal_errors(%{} = decoded) do
@@ -701,7 +790,8 @@ defmodule CodexPooler.Gateway.Transports.Streaming.StreamProtocol.PublicResponse
         created?: false,
         text_delta?: false,
         passthrough?: false,
-        passthrough_terminal: nil
+        passthrough_terminal: nil,
+        function_call_arguments: %{}
     }
   end
 

--- a/test/codex_pooler/gateway/openai_compatibility/chat_completions_test.exs
+++ b/test/codex_pooler/gateway/openai_compatibility/chat_completions_test.exs
@@ -111,5 +111,148 @@ defmodule CodexPooler.Gateway.OpenAICompatibility.ChatCompletionsTest do
       refute delta_chunk =~ "response.output_text.delta"
       refute state.discarding_oversized?
     end
+
+    test "does not replay function arguments from a completed output item" do
+      arguments = ~s({"file_path":"","name":"hermes-agent"})
+
+      events = [
+        function_call_item_event("response.output_item.added", arguments),
+        function_call_item_event("response.output_item.done", arguments)
+      ]
+
+      {stream, _state} = normalize_events(events)
+
+      assert tool_argument_fragments(stream) == [arguments]
+      assert tool_call_ids(stream) == ["call_hermes"]
+    end
+
+    test "converts cumulative function argument snapshots into non-overlapping deltas" do
+      arguments = ~s({"file_path":"references/native-mcp.md","name":"hermes-agent"})
+
+      events = [
+        function_call_item_event("response.output_item.added", ""),
+        function_arguments_event(~s({"file)),
+        function_arguments_event(~s({"file_path":"references/)),
+        function_arguments_event(arguments),
+        function_call_item_event("response.output_item.done", arguments)
+      ]
+
+      {stream, _state} = normalize_events(events)
+
+      assert tool_argument_fragments(stream) |> Enum.join() == arguments
+      assert tool_call_ids(stream) == ["call_hermes"]
+    end
+
+    test "preserves true argument deltas and reconciles a missing suffix from done" do
+      arguments = ~s({"file_path":"references/native-mcp.md","name":"hermes-agent"})
+
+      events = [
+        function_call_item_event("response.output_item.added", ""),
+        function_arguments_event(~s({"file)),
+        function_arguments_event(~s(_path":"references/)),
+        function_arguments_done_event(arguments)
+      ]
+
+      {stream, _state} = normalize_events(events)
+
+      assert tool_argument_fragments(stream) |> Enum.join() == arguments
+      assert tool_call_ids(stream) == ["call_hermes"]
+    end
+  end
+
+  defp normalize_events(events) do
+    Enum.reduce(
+      events,
+      {"", ChatCompletions.stream_state(%{"model" => "gpt-example"})},
+      fn event, {stream, state} ->
+        {chunk, state} = ChatCompletions.normalize_stream_data(event, state)
+        {stream <> chunk, state}
+      end
+    )
+  end
+
+  defp function_call_item_event(type, arguments) do
+    sse_event(type, %{
+      "type" => type,
+      "output_index" => 0,
+      "item" => %{
+        "type" => "function_call",
+        "id" => "fc_hermes",
+        "call_id" => "call_hermes",
+        "name" => "read_file",
+        "arguments" => arguments
+      }
+    })
+  end
+
+  defp function_arguments_event(arguments) do
+    sse_event("response.function_call_arguments.delta", %{
+      "type" => "response.function_call_arguments.delta",
+      "output_index" => 0,
+      "item_id" => "fc_hermes",
+      "delta" => arguments
+    })
+  end
+
+  defp function_arguments_done_event(arguments) do
+    sse_event("response.function_call_arguments.done", %{
+      "type" => "response.function_call_arguments.done",
+      "output_index" => 0,
+      "item_id" => "fc_hermes",
+      "arguments" => arguments
+    })
+  end
+
+  defp sse_event(type, payload) do
+    ["event: ", type, "\n", "data: ", Jason.encode!(payload), "\n\n"]
+    |> IO.iodata_to_binary()
+  end
+
+  defp tool_argument_fragments(stream) do
+    stream
+    |> chat_chunks()
+    |> Enum.flat_map(fn chunk ->
+      case get_in(chunk, ["choices", Access.at(0), "delta", "tool_calls"]) do
+        tool_calls when is_list(tool_calls) ->
+          Enum.flat_map(tool_calls, fn tool_call ->
+            case get_in(tool_call, ["function", "arguments"]) do
+              arguments when is_binary(arguments) and arguments != "" -> [arguments]
+              _arguments -> []
+            end
+          end)
+
+        _tool_calls ->
+          []
+      end
+    end)
+  end
+
+  defp tool_call_ids(stream) do
+    stream
+    |> chat_chunks()
+    |> Enum.flat_map(fn chunk ->
+      case get_in(chunk, ["choices", Access.at(0), "delta", "tool_calls"]) do
+        tool_calls when is_list(tool_calls) ->
+          Enum.flat_map(tool_calls, fn
+            %{"id" => id} when is_binary(id) -> [id]
+            _tool_call -> []
+          end)
+
+        _tool_calls ->
+          []
+      end
+    end)
+  end
+
+  defp chat_chunks(stream) do
+    stream
+    |> String.split("\n\n", trim: true)
+    |> Enum.flat_map(fn block ->
+      case StreamProtocol.sse_field(block, "data") do
+        nil -> []
+        "[DONE]" -> []
+        data -> [Jason.decode!(data)]
+      end
+    end)
   end
 end

--- a/test/codex_pooler/gateway/transports/stream_protocol_test.exs
+++ b/test/codex_pooler/gateway/transports/stream_protocol_test.exs
@@ -123,6 +123,79 @@ defmodule CodexPooler.Gateway.Transports.Streaming.StreamProtocolTest do
              }
     end
 
+    test "normalizes cumulative function argument snapshots into true deltas" do
+      state = StreamProtocol.public_openai_responses_stream_state()
+      first_arguments = ~s({"file_path":"references/native-mcp.md","name":"hermes-agent"})
+      second_arguments = ~s({"name":"second-tool"})
+
+      stream =
+        IO.iodata_to_binary([
+          sse_event("response.output_item.added", %{
+            "type" => "response.output_item.added",
+            "output_index" => 0,
+            "item" => %{
+              "id" => "fc_hermes",
+              "call_id" => "call_hermes",
+              "type" => "function_call",
+              "name" => "read_file",
+              "arguments" => ""
+            }
+          }),
+          sse_event("response.output_item.added", %{
+            "type" => "response.output_item.added",
+            "output_index" => 1,
+            "item" => %{
+              "id" => "fc_second",
+              "call_id" => "call_second",
+              "type" => "function_call",
+              "name" => "second_tool",
+              "arguments" => ""
+            }
+          }),
+          function_arguments_delta(0, ~s({"file)),
+          function_arguments_delta(1, ~s({"name")),
+          function_arguments_delta(0, first_arguments),
+          function_arguments_delta(1, ~s(:"second-tool"})),
+          function_arguments_delta(0, first_arguments),
+          sse_event("response.function_call_arguments.done", %{
+            "type" => "response.function_call_arguments.done",
+            "output_index" => 0,
+            "item_id" => "fc_hermes",
+            "arguments" => first_arguments
+          }),
+          sse_event("response.output_item.done", %{
+            "type" => "response.output_item.done",
+            "output_index" => 0,
+            "item" => %{
+              "id" => "fc_hermes",
+              "call_id" => "call_hermes",
+              "type" => "function_call",
+              "name" => "read_file",
+              "arguments" => first_arguments
+            }
+          })
+        ])
+
+      assert {chunk, _state} =
+               StreamProtocol.normalize_public_openai_responses_sse_data(stream, state)
+
+      deltas_by_index =
+        chunk
+        |> public_sse_events()
+        |> Enum.filter(&(&1["event"] == "response.function_call_arguments.delta"))
+        |> Enum.group_by(&get_in(&1, ["data", "output_index"]), &get_in(&1, ["data", "delta"]))
+
+      assert Enum.join(deltas_by_index[0]) == first_arguments
+      assert List.last(deltas_by_index[0]) == ""
+      assert Enum.join(deltas_by_index[1]) == second_arguments
+
+      assert %{"arguments" => ^first_arguments} =
+               chunk
+               |> public_sse_events()
+               |> Enum.find(&(&1["event"] == "response.function_call_arguments.done"))
+               |> get_in(["data"])
+    end
+
     test "passes keepalive events through without changing terminal state" do
       state = StreamProtocol.public_openai_responses_stream_state()
 
@@ -867,6 +940,15 @@ defmodule CodexPooler.Gateway.Transports.Streaming.StreamProtocolTest do
           "total_tokens" => 12
         }
       }
+    })
+  end
+
+  defp function_arguments_delta(output_index, delta) do
+    sse_event("response.function_call_arguments.delta", %{
+      "type" => "response.function_call_arguments.delta",
+      "output_index" => output_index,
+      "item_id" => "fc_#{output_index}",
+      "delta" => delta
     })
   end
 


### PR DESCRIPTION
## Summary

- Normalize accumulated ChatGPT Web function-call argument snapshots into OpenAI-compatible deltas.
- Track arguments independently per tool call in Chat Completions and public Responses streams.
- Reconcile terminal snapshots without replaying JSON that was already emitted.

## Problem

The ChatGPT Web backend can stream accumulated argument values rather than deltas. Appending those values downstream duplicates JSON tool arguments, producing invalid Hermes tool calls and contributing to early length truncation.

## Tests

- Added regressions for accumulated snapshots, genuine deltas, terminal reconciliation, and interleaved tool calls.
- The focused regression run passed (72 tests, including both streaming suites).

This PR intentionally excludes the unrelated quota-reset reconciliation change.