### PR TITLE
fix(quota): accept confirmed idle zero reset reanchors

### DIFF
--- a/lib/codex_pooler/upstreams/quota/windows/evidence_store.ex
+++ b/lib/codex_pooler/upstreams/quota/windows/evidence_store.ex
@@ -618,9 +618,31 @@ defmodule CodexPooler.Upstreams.Quota.Windows.EvidenceStore do
     candidate_valid?(candidate, timestamp) and
       zero_candidate?(candidate) and
       reset_times_equivalent?(candidate.reset_at, evidence.reset_at) and
-      exhausted_by_used_percent?(existing) and
+      (exhausted_by_used_percent?(existing) or
+         confirmed_idle_zero_forward_anchor?(evidence, existing)) and
       forward_of_existing_cycle?(evidence, existing)
   end
+
+  # An accepted idle weekly zero can receive a provider-timed anchor a few
+  # minutes ahead of its canonical reset. Let that zero-to-zero correction use
+  # the existing candidate, liveness, and confirmation-span gates instead of
+  # restarting the candidate forever. Larger shifts remain new-cycle evidence.
+  defp confirmed_idle_zero_forward_anchor?(
+         %Evidence{reset_at: %DateTime{} = incoming_reset, used_percent: %Decimal{} = incoming} =
+           evidence,
+         %Quota.AccountQuotaWindow{
+           reset_at: %DateTime{} = existing_reset,
+           used_percent: %Decimal{} = existing
+         } = window
+       ) do
+    zero_percent?(incoming) and
+      zero_percent?(existing) and
+      anchored_forward_weekly_cycle?(evidence, window) and
+      DateTime.diff(incoming_reset, existing_reset, :second) <=
+        @usage_reset_reanchor_min_shift_seconds
+  end
+
+  defp confirmed_idle_zero_forward_anchor?(_evidence, _existing), do: false
 
   defp forward_of_existing_cycle?(
          %Evidence{reset_at: %DateTime{} = incoming_reset},

--- a/test/codex_pooler/upstreams/quota/windows/evidence_store_weekly_restart_test.exs
+++ b/test/codex_pooler/upstreams/quota/windows/evidence_store_weekly_restart_test.exs
@@ -464,6 +464,79 @@ defmodule CodexPooler.Upstreams.Quota.Windows.EvidenceStoreWeeklyRestartTest do
              Routing.eligibility_from_windows([row], at: row.observed_at)
   end
 
+  test "a live idle zero tolerates small forward reset drift without starving stale" do
+    t0 = DateTime.utc_now() |> DateTime.add(-30, :minute) |> DateTime.truncate(:microsecond)
+    identity = identity!()
+    canonical_reset = DateTime.add(t0, 5, :day)
+
+    assert {:ok, _row} =
+             used_row!(identity, t0, "0",
+               reset_at: canonical_reset,
+               metadata: %{
+                 "reset_after_seconds" => DateTime.diff(canonical_reset, t0, :second)
+               }
+             )
+
+    live_at = DateTime.add(t0, 20, :minute)
+    drifted_reset = DateTime.add(canonical_reset, 301, :second)
+    remaining_seconds = DateTime.diff(drifted_reset, live_at, :second)
+    candidate_at = DateTime.add(live_at, -4, :minute)
+
+    account_row(identity)
+    |> Ecto.Changeset.change(
+      metadata: %{
+        "reset_after_seconds" => DateTime.diff(canonical_reset, t0, :second),
+        "__quota_confirmed_candidate_v1" => %{
+          "version" => 1,
+          "used_percent" => "0",
+          "reset_at" => DateTime.to_iso8601(drifted_reset),
+          "observed_at" => DateTime.to_iso8601(candidate_at),
+          "count" => 1
+        },
+        "__quota_relative_candidate_liveness_v1" => DateTime.to_iso8601(candidate_at)
+      }
+    )
+    |> Repo.update!()
+
+    assert {:ok, _row} =
+             EvidenceStore.record_evidence(
+               identity,
+               floating_zero(live_at,
+                 reset_at: drifted_reset,
+                 reset_after_seconds: remaining_seconds
+               ),
+               live_at,
+               live_at
+             )
+
+    row = account_row(identity)
+    assert Decimal.equal?(row.used_percent, Decimal.new("0"))
+    assert DateTime.compare(row.observed_at, live_at) == :eq
+    assert DateTime.compare(row.reset_at, drifted_reset) == :eq
+    refute Map.has_key?(row.metadata, "__quota_confirmed_candidate_v1")
+    refute Map.has_key?(row.metadata, "__quota_relative_candidate_liveness_v1")
+
+    assert %{eligible?: true, routing_state: :weekly_only_probe} =
+             Routing.eligibility_from_windows([row], at: live_at)
+
+    replayed_at = DateTime.add(live_at, 16, :minute)
+
+    assert {:ok, _row} =
+             EvidenceStore.record_evidence(
+               identity,
+               floating_zero(replayed_at,
+                 reset_at: drifted_reset,
+                 reset_after_seconds: remaining_seconds
+               ),
+               replayed_at,
+               replayed_at
+             )
+
+    replayed = account_row(identity)
+    assert DateTime.compare(replayed.observed_at, live_at) == :eq
+    assert Evidence.current_freshness_state(replayed, replayed_at) == "stale"
+  end
+
   test "a cached superseded reset cannot keep an accepted weekly zero fresh" do
     t0 = DateTime.utc_now() |> DateTime.add(-20, :minute) |> DateTime.truncate(:microsecond)
     identity = identity!()


### PR DESCRIPTION
## Summary

- Allow a confirmed idle weekly zero to move its canonical reset to a slightly newer provider anchor.
- Reuse the existing candidate-liveness and three-minute confirmation gates so a small reset drift cannot restart confirmation forever.
- Keep fixed cached replays from refreshing the accepted window, so stale quota evidence still ages out fail-closed.

## Problem

A live provider window can remain at 0% used while its anchored reset moves just beyond the five-minute equivalence tolerance. A 301-second drift repeatedly restarted the candidate because the canonical row was already 0%, leaving its observation timestamp stale and allowing older exhausted runtime evidence to dominate routing.

## Safety

The zero-to-zero correction still requires matching candidates, relative liveness progress, the existing confirmation span, an anchored weekly-cycle shape, and a bounded forward shift of at most one hour.

## Tests

- Adds a regression for the 301-second live reset drift.
- Verifies the confirmed row becomes routable and a later fixed-body replay cannot keep it fresh.
- The focused 72-test regression run covering this test passed before isolation; the isolated diff also passes Git whitespace validation.

This PR intentionally excludes the broader reconciliation/UI work and the Hermes streaming fix.