### PR TITLE
fix(routing): fall back across canonical partitions

### DIFF
--- a/lib/codex_pooler/gateway/metadata/codex_catalog.ex
+++ b/lib/codex_pooler/gateway/metadata/codex_catalog.ex
@@ -142,6 +142,16 @@ defmodule CodexPooler.Gateway.Metadata.CodexCatalog do
     end)
   end
 
+  @spec canonical_source_partitions(Model.t(), [candidate()]) :: [selected_partition()]
+  def canonical_source_partitions(%Model{} = model, candidates) when is_list(candidates) do
+    model
+    |> canonical_pairs(candidates)
+    |> Enum.group_by(& &1.digest)
+    |> Enum.map(fn {_digest, pairs} -> build_partition(pairs, model) end)
+    |> Enum.sort_by(& &1.anchor)
+    |> Enum.map(&Map.delete(&1, :anchor))
+  end
+
   @spec valid_canonical_assignment_ids(Model.t(), [candidate()]) :: [Ecto.UUID.t()]
   def valid_canonical_assignment_ids(%Model{} = model, candidates) when is_list(candidates) do
     model
@@ -244,8 +254,8 @@ defmodule CodexPooler.Gateway.Metadata.CodexCatalog do
 
   defp select_model_partition(%Model{} = model, candidates) when is_list(candidates) do
     model
-    |> canonical_pairs(candidates)
-    |> select_anchored_partition(model)
+    |> canonical_source_partitions(candidates)
+    |> List.first()
   end
 
   defp select_model_partition(%Model{}, _candidates), do: nil
@@ -285,14 +295,12 @@ defmodule CodexPooler.Gateway.Metadata.CodexCatalog do
 
   defp valid_source_slug?(_source, %Model{}), do: false
 
-  defp select_anchored_partition([], %Model{}), do: nil
-
-  defp select_anchored_partition(pairs, %Model{} = model) do
+  defp build_partition(pairs, %Model{} = model) do
     anchor = Enum.min_by(pairs, &{&1.created_at, &1.assignment_id})
-    members = Map.fetch!(Enum.group_by(pairs, & &1.digest), anchor.digest)
 
     %{
-      assignment_ids: members |> Enum.map(& &1.assignment_id) |> Enum.sort(),
+      anchor: {anchor.created_at, anchor.assignment_id},
+      assignment_ids: pairs |> Enum.map(& &1.assignment_id) |> Enum.sort(),
       digest: anchor.digest,
       model: model,
       source: anchor.source

--- a/lib/codex_pooler/gateway/routing/candidate_eligibility.ex
+++ b/lib/codex_pooler/gateway/routing/candidate_eligibility.ex
@@ -128,6 +128,7 @@ defmodule CodexPooler.Gateway.Routing.CandidateEligibility do
           required(:visible_candidates_by_model_id) => %{optional(Ecto.UUID.t()) => [candidate()]},
           required(:candidate_snapshots) => [candidate()],
           optional(:selected_partition_assignment_ids) => [Ecto.UUID.t()],
+          optional(:canonical_partition_assignment_ids) => [[Ecto.UUID.t()]],
           optional(:valid_canonical_assignment_ids) => [Ecto.UUID.t()],
           required(:hydrated_at) => DateTime.t()
         }

--- a/lib/codex_pooler/gateway/routing/route_filtering.ex
+++ b/lib/codex_pooler/gateway/routing/route_filtering.ex
@@ -6,6 +6,7 @@ defmodule CodexPooler.Gateway.Routing.RouteFiltering do
   alias CodexPooler.Gateway.Routing.CandidateEligibility
   alias CodexPooler.Gateway.Routing.QuotaRefresh.{Executor, Plan}
   alias CodexPooler.Gateway.Routing.SavedResetAutoRedeem
+  alias CodexPooler.Gateway.Routing.SessionContinuity
   alias CodexPooler.Gateway.Runtime.Dispatch.RouteState
 
   @type candidate :: CandidateEligibility.FilterInput.candidate()
@@ -34,8 +35,38 @@ defmodule CodexPooler.Gateway.Routing.RouteFiltering do
       when is_list(opts) do
     saved_reset_scan_at = saved_reset_scan_timestamp(opts)
     saved_reset_opts = saved_reset_options(opts)
-    request_options = filter_input.request_options
     quota_mode = Keyword.get(opts, :quota_mode, :required)
+
+    case filter_partition(
+           filter_input,
+           route_state,
+           quota_mode,
+           saved_reset_scan_at,
+           saved_reset_opts
+         ) do
+      {:ok, _candidates, _request_options, _route_state} = result ->
+        result
+
+      {:error, _reason} = primary_error ->
+        maybe_filter_fallback_partitions(
+          primary_error,
+          filter_input,
+          route_state,
+          quota_mode,
+          saved_reset_scan_at,
+          saved_reset_opts
+        )
+    end
+  end
+
+  defp filter_partition(
+         %CandidateEligibility.FilterInput{} = filter_input,
+         %RouteState{} = route_state,
+         quota_mode,
+         saved_reset_scan_at,
+         saved_reset_opts
+       ) do
+    request_options = filter_input.request_options
 
     with {:ok, candidates} <-
            CandidateEligibility.filter_circuit_eligible_candidates(filter_input, route_state),
@@ -63,6 +94,58 @@ defmodule CodexPooler.Gateway.Routing.RouteFiltering do
       {:ok, candidates, request_options, RouteState.put_candidates(route_state, candidates)}
     end
   end
+
+  defp maybe_filter_fallback_partitions(
+         {:error, %{code: code}} = primary_error,
+         %CandidateEligibility.FilterInput{} = filter_input,
+         %RouteState{fallback_candidate_partitions: fallback_partitions} = route_state,
+         quota_mode,
+         saved_reset_scan_at,
+         saved_reset_opts
+       )
+       when code in [
+              "no_eligible_backend",
+              :no_eligible_backend,
+              "quota_exhausted",
+              :quota_exhausted,
+              "quota_evidence_unavailable",
+              :quota_evidence_unavailable
+            ] and fallback_partitions != [] do
+    if SessionContinuity.hard_pin_metadata(
+         filter_input.request_options,
+         filter_input.model
+       ) == nil do
+      Enum.reduce_while(fallback_partitions, primary_error, fn candidates, _last_error ->
+        fallback_filter_input =
+          CandidateEligibility.FilterInput.put_candidates(filter_input, candidates)
+
+        fallback_route_state = RouteState.put_candidates(route_state, candidates)
+
+        case filter_partition(
+               fallback_filter_input,
+               fallback_route_state,
+               quota_mode,
+               saved_reset_scan_at,
+               saved_reset_opts
+             ) do
+          {:ok, _candidates, _request_options, _route_state} = result -> {:halt, result}
+          {:error, _reason} = error -> {:cont, error}
+        end
+      end)
+    else
+      primary_error
+    end
+  end
+
+  defp maybe_filter_fallback_partitions(
+         primary_error,
+         %CandidateEligibility.FilterInput{},
+         %RouteState{},
+         _quota_mode,
+         _saved_reset_scan_at,
+         _saved_reset_opts
+       ),
+       do: primary_error
 
   defp filter_quota_eligible_candidates(
          %CandidateEligibility.FilterInput{} = filter_input,

--- a/lib/codex_pooler/gateway/runtime/dispatch/pre_dispatch.ex
+++ b/lib/codex_pooler/gateway/runtime/dispatch/pre_dispatch.ex
@@ -140,9 +140,20 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch.PreDispatch do
              request_options,
              model
            ) do
+      fallback_candidate_partitions =
+        fallback_candidate_partitions(
+          partition_input_candidates,
+          candidates,
+          visible_model_context,
+          endpoint,
+          request_options,
+          model
+        )
+
       route_state =
         route_state
         |> RouteState.put_candidates(candidates)
+        |> RouteState.put_fallback_candidate_partitions(fallback_candidate_partitions)
         |> RouteState.preload_routing_snapshots(auth, model, request_options)
         |> RouteState.put_reservation_snapshot_inputs(
           AccountingReservation.reservation_snapshot_inputs(
@@ -162,14 +173,21 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch.PreDispatch do
     candidates_by_model_id = Map.get(visible_model_context, :candidates_by_model_id, %{})
     candidates = Map.get(candidates_by_model_id, model.id, [])
 
+    partitions = CodexCatalog.canonical_source_partitions(model, candidates)
+
     assignment_ids =
-      case CodexCatalog.select_canonical_sources([model], candidates_by_model_id) do
+      case partitions do
         [%{assignment_ids: assignment_ids}] -> assignment_ids
+        [%{assignment_ids: assignment_ids} | _partitions] -> assignment_ids
         [] -> []
       end
 
     visible_model_context
     |> Map.put(:selected_partition_assignment_ids, assignment_ids)
+    |> Map.put(
+      :canonical_partition_assignment_ids,
+      Enum.map(partitions, & &1.assignment_ids)
+    )
     |> Map.put(
       :valid_canonical_assignment_ids,
       CodexCatalog.valid_canonical_assignment_ids(model, candidates)
@@ -193,6 +211,63 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch.PreDispatch do
        do: assignment_id
 
   defp codex_session_assignment_id(%RequestOptions{}), do: nil
+
+  defp fallback_candidate_partitions(
+         partition_input_candidates,
+         selected_candidates,
+         visible_model_context,
+         endpoint,
+         %RequestOptions{} = request_options,
+         %Model{} = model
+       ) do
+    if SessionContinuity.hard_pin_metadata(request_options, model) do
+      []
+    else
+      selected_assignment_ids =
+        selected_candidates
+        |> Enum.map(fn {assignment, _identity} -> assignment.id end)
+        |> MapSet.new()
+
+      candidates_by_assignment_id =
+        Map.new(partition_input_candidates, fn {assignment, _identity} = candidate ->
+          {assignment.id, candidate}
+        end)
+
+      visible_model_context
+      |> Map.get(:canonical_partition_assignment_ids, [])
+      |> Enum.flat_map(fn assignment_ids ->
+        candidates =
+          assignment_ids
+          |> Enum.reject(&MapSet.member?(selected_assignment_ids, &1))
+          |> Enum.flat_map(fn assignment_id ->
+            case Map.fetch(candidates_by_assignment_id, assignment_id) do
+              {:ok, candidate} -> [candidate]
+              :error -> []
+            end
+          end)
+
+        case filter_fallback_partition(candidates, endpoint, request_options, model) do
+          {:ok, candidates} -> [candidates]
+          {:error, _reason} -> []
+        end
+      end)
+    end
+  end
+
+  defp filter_fallback_partition(
+         candidates,
+         endpoint,
+         %RequestOptions{} = request_options,
+         %Model{} = model
+       ) do
+    with {:ok, candidates} <- SessionContinuity.filter_file_affinity(candidates, request_options),
+         {:ok, candidates} <- CandidateEligibility.maybe_filter_compact(endpoint, candidates),
+         {:ok, candidates} <-
+           SessionContinuity.apply_codex_session_assignment(candidates, request_options, model),
+         :ok <- ensure_candidates_available(candidates) do
+      {:ok, candidates}
+    end
+  end
 
   defp finish_partition_filtering(
          candidates,

--- a/lib/codex_pooler/gateway/runtime/dispatch/route_state.ex
+++ b/lib/codex_pooler/gateway/runtime/dispatch/route_state.ex
@@ -19,6 +19,7 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch.RouteState do
     effective_model_serving_modes: %{},
     candidate_snapshots: [],
     candidates: [],
+    fallback_candidate_partitions: [],
     routing_settings: nil,
     quota_window_snapshots: %{},
     quota_snapshot_at: nil,
@@ -58,6 +59,7 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch.RouteState do
           effective_model_serving_modes: effective_model_serving_modes(),
           candidate_snapshots: [candidate()],
           candidates: [candidate()],
+          fallback_candidate_partitions: [[candidate()]],
           routing_settings: RoutingSettings.t() | nil,
           quota_window_snapshots: quota_window_snapshots(),
           quota_snapshot_at: DateTime.t() | nil,
@@ -75,6 +77,7 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch.RouteState do
           optional(:visible_models) => [Model.t()],
           optional(:effective_model_serving_modes) => effective_model_serving_modes(),
           optional(:candidate_snapshots) => [candidate()],
+          optional(:fallback_candidate_partitions) => [[candidate()]],
           optional(:routing_settings) => RoutingSettings.t() | nil,
           optional(:quota_window_snapshots) => quota_window_snapshots(),
           optional(:quota_snapshot_at) => DateTime.t() | nil,
@@ -96,6 +99,7 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch.RouteState do
       effective_model_serving_modes: Map.get(attrs, :effective_model_serving_modes, %{}),
       candidate_snapshots: Map.get(attrs, :candidate_snapshots, candidates),
       candidates: candidates,
+      fallback_candidate_partitions: Map.get(attrs, :fallback_candidate_partitions, []),
       routing_settings: Map.get(attrs, :routing_settings),
       circuit_snapshots: circuit_snapshots(attrs),
       circuit_eligibility_snapshots: circuit_snapshots(attrs),
@@ -112,6 +116,11 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch.RouteState do
   @spec put_candidates(t(), [candidate()]) :: t()
   def put_candidates(%__MODULE__{} = route_state, candidates) when is_list(candidates),
     do: %{route_state | candidates: candidates}
+
+  @spec put_fallback_candidate_partitions(t(), [[candidate()]]) :: t()
+  def put_fallback_candidate_partitions(%__MODULE__{} = route_state, partitions)
+      when is_list(partitions),
+      do: %{route_state | fallback_candidate_partitions: partitions}
 
   @spec put_reset_probe(t(), ResetProbe.t()) :: t()
   def put_reset_probe(%__MODULE__{} = route_state, %ResetProbe{} = reset_probe),
@@ -168,11 +177,12 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch.RouteState do
 
   @spec preload_routing_snapshots(t(), auth(), Model.t(), RequestOptions.t()) :: t()
   def preload_routing_snapshots(
-        %__MODULE__{candidates: candidates} = route_state,
+        %__MODULE__{} = route_state,
         auth,
         %Model{} = model,
         %RequestOptions{} = request_options
       ) do
+    candidates = routing_snapshot_candidates(route_state)
     route_class = RequestOptions.route_class(request_options)
     {quota_window_snapshots, quota_snapshot_at} = load_quota_window_snapshot(candidates)
 
@@ -213,6 +223,12 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch.RouteState do
 
   defp circuit_snapshots(attrs) do
     Map.get(attrs, :circuit_snapshots, Map.get(attrs, :circuit_eligibility_snapshots, %{}))
+  end
+
+  defp routing_snapshot_candidates(%__MODULE__{} = route_state) do
+    [route_state.candidates | route_state.fallback_candidate_partitions]
+    |> List.flatten()
+    |> Enum.uniq_by(fn {assignment, _identity} -> assignment.id end)
   end
 
   defp load_quota_window_snapshot(candidates) do

--- a/test/codex_pooler/gateway/routing/route_filtering_test.exs
+++ b/test/codex_pooler/gateway/routing/route_filtering_test.exs
@@ -221,6 +221,132 @@ defmodule CodexPooler.Gateway.Routing.RouteFilteringTest do
                RouteFiltering.filter_candidates(filter_input)
     end
 
+    test "falls back to the next canonical partition when the selected partition is exhausted" do
+      %{pool: pool, api_key: api_key} = active_api_key_fixture()
+      selected = active_upstream_assignment_fixture(pool, %{account_label: "Selected partition"})
+      fallback = active_upstream_assignment_fixture(pool, %{account_label: "Fallback partition"})
+
+      model =
+        model_fixture(pool, %{
+          exposed_model_id: "gpt-partition-fallback-#{System.unique_integer([:positive])}",
+          metadata: %{
+            "source_assignment_ids" => [selected.assignment.id, fallback.assignment.id]
+          }
+        })
+
+      selected_candidate = {selected.assignment, selected.identity}
+      fallback_candidate = {fallback.assignment, fallback.identity}
+      filter_input = filter_input(pool, api_key, model, [selected_candidate])
+
+      upsert_primary_quota!(selected.identity, Decimal.new("100"))
+      upsert_primary_quota!(fallback.identity, Decimal.new("15"))
+
+      route_state =
+        RouteState.new(%{
+          visible_model: model,
+          candidates: [selected_candidate],
+          fallback_candidate_partitions: [[fallback_candidate]]
+        })
+        |> RouteState.preload_routing_snapshots(
+          filter_input.auth,
+          model,
+          filter_input.request_options
+        )
+
+      assert {:ok, [{routed_assignment, _identity}], request_options, returned_route_state} =
+               RouteFiltering.filter_candidates_with_route_state(filter_input, route_state)
+
+      assert routed_assignment.id == fallback.assignment.id
+      assert request_options.routing.quota_decision["routing_state"] == "precise"
+      assert candidate_ids(returned_route_state.candidates) == [fallback.assignment.id]
+    end
+
+    test "keeps the selected canonical partition while it remains eligible" do
+      %{pool: pool, api_key: api_key} = active_api_key_fixture()
+      selected = active_upstream_assignment_fixture(pool, %{account_label: "Selected partition"})
+      fallback = active_upstream_assignment_fixture(pool, %{account_label: "Fallback partition"})
+
+      model =
+        model_fixture(pool, %{
+          exposed_model_id: "gpt-partition-preferred-#{System.unique_integer([:positive])}",
+          metadata: %{
+            "source_assignment_ids" => [selected.assignment.id, fallback.assignment.id]
+          }
+        })
+
+      selected_candidate = {selected.assignment, selected.identity}
+      fallback_candidate = {fallback.assignment, fallback.identity}
+      filter_input = filter_input(pool, api_key, model, [selected_candidate])
+
+      upsert_primary_quota!(selected.identity, Decimal.new("15"))
+      upsert_primary_quota!(fallback.identity, Decimal.new("15"))
+
+      route_state =
+        RouteState.new(%{
+          visible_model: model,
+          candidates: [selected_candidate],
+          fallback_candidate_partitions: [[fallback_candidate]]
+        })
+        |> RouteState.preload_routing_snapshots(
+          filter_input.auth,
+          model,
+          filter_input.request_options
+        )
+
+      assert {:ok, [{routed_assignment, _identity}], _request_options, _route_state} =
+               RouteFiltering.filter_candidates_with_route_state(filter_input, route_state)
+
+      assert routed_assignment.id == selected.assignment.id
+    end
+
+    test "does not cross canonical partitions for a hard-pinned continuation" do
+      %{pool: pool, api_key: api_key} = active_api_key_fixture()
+      selected = active_upstream_assignment_fixture(pool, %{account_label: "Pinned partition"})
+      fallback = active_upstream_assignment_fixture(pool, %{account_label: "Fallback partition"})
+
+      model =
+        model_fixture(pool, %{
+          exposed_model_id: "gpt-partition-hard-pin-#{System.unique_integer([:positive])}",
+          metadata: %{
+            "source_assignment_ids" => [selected.assignment.id, fallback.assignment.id]
+          }
+        })
+
+      selected_candidate = {selected.assignment, selected.identity}
+      fallback_candidate = {fallback.assignment, fallback.identity}
+
+      filter_input =
+        pool
+        |> filter_input(api_key, model, [selected_candidate])
+        |> then(fn input ->
+          request_options =
+            RequestOptions.put_continuity(
+              input.request_options,
+              previous_response_id: "response-hard-pin"
+            )
+
+          FilterInput.put_request_options(input, request_options)
+        end)
+
+      upsert_primary_quota!(selected.identity, Decimal.new("100"))
+      upsert_primary_quota!(fallback.identity, Decimal.new("15"))
+
+      route_state =
+        RouteState.new(%{
+          visible_model: model,
+          candidates: [selected_candidate],
+          fallback_candidate_partitions: [[fallback_candidate]]
+        })
+        |> RouteState.preload_routing_snapshots(
+          filter_input.auth,
+          model,
+          filter_input.request_options
+        )
+
+      assert {:error, %{code: "pinned_continuation_unavailable"}} =
+               RouteFiltering.filter_candidates_with_route_state(filter_input, route_state)
+    end
+
     test "does not redeem saved reset when auto policy is disabled by default" do
       {:ok, upstream} =
         FakeUpstream.start_link({:path_json, %{"/api/codex/usage" => {200, usage_payload(0)}}})

--- a/test/codex_pooler/gateway/runtime/pre_dispatch_test.exs
+++ b/test/codex_pooler/gateway/runtime/pre_dispatch_test.exs
@@ -639,6 +639,21 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch.PreDispatchTest do
            ]
 
     assert candidate_ids(prepared.candidates) == [setup.assignment.id]
+
+    assert Enum.map(
+             prepared.route_state.fallback_candidate_partitions,
+             &candidate_ids/1
+           ) == [[divergent.assignment.id]]
+
+    assert Map.has_key?(
+             prepared.route_state.quota_window_snapshots,
+             divergent.identity.id
+           )
+
+    assert Map.has_key?(
+             prepared.route_state.circuit_snapshots,
+             divergent.assignment.id
+           )
   end
 
   test "a compatible hard-pinned continuation stays on a non-selected schema partition" do


### PR DESCRIPTION
## Why

Canonical source selection currently removes assignments outside the oldest schema partition before quota and circuit filtering. If every assignment in that partition is exhausted or circuit-blocked, routing returns a 503 even when another canonical partition contains a healthy account.

This was reproduced with two assignments advertising the same model through different canonical metadata digests: the exhausted assignment reached quota filtering, while the healthy assignment was absent from the candidate set.

## What changed

- Expose canonical source partitions in deterministic anchor order while preserving the existing oldest-partition catalog selection.
- Retain runtime-compatible alternate partitions in `RouteState` and preload quota/circuit snapshots for all of them at one observation boundary.
- Retry complete alternate partitions only after `quota_exhausted`, `quota_evidence_unavailable`, or `no_eligible_backend` from the selected partition.
- Preserve the selected partition while it is eligible and prohibit cross-partition fallback for hard-pinned continuations and file affinity.
- Add regression coverage for fallback, selected-partition preference, hard-pin isolation, and alternate snapshot preloading.

## Validation

Executed with Elixir 1.20.1 / OTP 28 in containers:

- `mix test test/codex_pooler/gateway/metadata/codex_catalog_test.exs test/codex_pooler/gateway/runtime/pre_dispatch_test.exs test/codex_pooler/gateway/routing/route_filtering_test.exs` — 81 passed.
- `mix test` — 5255 passed; 5 environment-only failures reported `make not found` in the initial slim container.
- After installing `build-essential`, `mix test test/codex_pooler/gateway/runtime/streaming/first_event_classifier_differential_test.exs test/mix/tasks/test_fast_make_test.exs` — 16 passed, covering those 5 failures and the remaining tests in those files.
- `mix compile --warnings-as-errors` — passed.
- `mix format --check-formatted` for all changed Elixir files — passed.

## Risk and rollback

The behavioral risk is limited to fresh or soft-pinned requests after the selected canonical partition has no eligible candidate. Alternate candidates remain grouped by schema digest and are attempted one partition at a time; hard-pinned continuity never crosses partitions. Snapshot preloading performs the existing bulk quota/circuit reads over a larger candidate set.

No database migration or configuration change is required. Roll back by reverting commit `08a0e393`; routing will return to selected-partition-only behavior.