### PR TITLE
fix(gateway): preserve v2 agent WebSocket handoffs

### DIFF
--- a/lib/codex_pooler/gateway/payloads/payload_normalizer.ex
+++ b/lib/codex_pooler/gateway/payloads/payload_normalizer.ex
@@ -577,10 +577,24 @@ defmodule CodexPooler.Gateway.Payloads.PayloadNormalizer do
          "content" => content
        })
        when is_list(content) do
-    Enum.any?(content, &backend_codex_encrypted_content_marker?/1)
+    Enum.any?(content, &backend_codex_encrypted_content_marker?/1) and
+      not backend_codex_encrypted_multi_agent_message?(content)
   end
 
   defp backend_codex_encrypted_agent_message?(_item), do: false
+
+  defp backend_codex_encrypted_multi_agent_message?([
+         %{"type" => "input_text", "text" => text},
+         %{"type" => "encrypted_content", "encrypted_content" => encrypted_content}
+       ])
+       when is_binary(text) and is_binary(encrypted_content) and encrypted_content != "" do
+    Regex.match?(
+      ~r/\AMessage Type: (?:NEW_TASK|MESSAGE)\nTask name: [^\n]+\nSender: [^\n]+\nPayload:\n\z/,
+      text
+    )
+  end
+
+  defp backend_codex_encrypted_multi_agent_message?(_content), do: false
 
   defp backend_codex_encrypted_content_marker?(%{} = item) do
     Map.get(item, "type") == "encrypted_content" ||

--- a/test/codex_pooler/gateway/payloads/payload_normalizer_test.exs
+++ b/test/codex_pooler/gateway/payloads/payload_normalizer_test.exs
@@ -232,6 +232,15 @@ defmodule CodexPooler.Gateway.Payloads.PayloadNormalizerTest do
             ]
           },
           %{
+            "type" => "agent_message",
+            "author" => "root",
+            "recipient" => "worker",
+            "content" => [
+              %{"type" => "input_text", "text" => "Message Type: NEW_TASK\nPayload:\n"},
+              %{"type" => "encrypted_content", "encrypted_content" => "lookalike-agent-message"}
+            ]
+          },
+          %{
             "type" => "message",
             "role" => "assistant",
             "content" => nil,
@@ -330,7 +339,7 @@ defmodule CodexPooler.Gateway.Payloads.PayloadNormalizerTest do
              ]
     end
 
-    test "removes backend Codex mixed encrypted agent messages from websocket upstream JSON" do
+    test "preserves backend Codex encrypted multi-agent MESSAGE envelopes in websocket upstream JSON" do
       payload = %{
         "model" => "gpt-5.5",
         "input" => [
@@ -340,7 +349,11 @@ defmodule CodexPooler.Gateway.Payloads.PayloadNormalizerTest do
             "author" => "root",
             "recipient" => "worker",
             "content" => [
-              %{"type" => "input_text", "text" => "Message Type: MESSAGE\nPayload:\n"},
+              %{
+                "type" => "input_text",
+                "text" =>
+                  "Message Type: MESSAGE\nTask name: /root\nSender: /root/worker\nPayload:\n"
+              },
               %{"type" => "encrypted_content", "encrypted_content" => "opaque-agent-message"}
             ]
           },
@@ -378,15 +391,89 @@ defmodule CodexPooler.Gateway.Payloads.PayloadNormalizerTest do
 
       assert Enum.map(upstream["input"], &Map.fetch!(&1, "type")) == [
                "message",
+               "agent_message",
                "message",
                "agent_message"
              ]
 
-      assert get_in(upstream, ["input", Access.at(1), "encrypted_content"]) ==
+      assert get_in(upstream, ["input", Access.at(1), "content"]) == [
+               %{
+                 "type" => "input_text",
+                 "text" =>
+                   "Message Type: MESSAGE\nTask name: /root\nSender: /root/worker\nPayload:\n"
+               },
+               %{"type" => "encrypted_content", "encrypted_content" => "opaque-agent-message"}
+             ]
+
+      assert get_in(upstream, ["input", Access.at(2), "encrypted_content"]) ==
                "preserved-assistant-replay"
 
-      assert get_in(upstream, ["input", Access.at(2), "content", Access.at(0), "type"]) ==
+      assert get_in(upstream, ["input", Access.at(3), "content", Access.at(0), "type"]) ==
                "input_text"
+    end
+
+    test "preserves encrypted multi-agent v2 NEW_TASK payloads in websocket upstream JSON" do
+      new_task = %{
+        "type" => "agent_message",
+        "author" => "/root",
+        "recipient" => "/root/worker",
+        "content" => [
+          %{
+            "type" => "input_text",
+            "text" => "Message Type: NEW_TASK\nTask name: /root/worker\nSender: /root\nPayload:\n"
+          },
+          %{"type" => "encrypted_content", "encrypted_content" => "opaque-new-task"}
+        ]
+      }
+
+      payload = %{"model" => "gpt-5.6", "input" => [new_task]}
+
+      request_options =
+        %{}
+        |> RequestOptions.build("/backend-api/codex/responses", payload)
+        |> RequestOptions.for_websocket(payload)
+
+      assert {:ok, encoded} =
+               PayloadNormalizer.upstream_payload(
+                 payload,
+                 %Model{upstream_model_id: "gpt-5.6"},
+                 "/backend-api/codex/responses",
+                 request_options
+               )
+
+      assert get_in(Jason.decode!(encoded), ["input", Access.at(0)]) == new_task
+    end
+
+    test "preserves encrypted multi-agent v2 MESSAGE payloads in websocket upstream JSON" do
+      message = %{
+        "type" => "agent_message",
+        "author" => "/root/worker",
+        "recipient" => "/root",
+        "content" => [
+          %{
+            "type" => "input_text",
+            "text" => "Message Type: MESSAGE\nTask name: /root\nSender: /root/worker\nPayload:\n"
+          },
+          %{"type" => "encrypted_content", "encrypted_content" => "opaque-message"}
+        ]
+      }
+
+      payload = %{"model" => "gpt-5.6", "input" => [message]}
+
+      request_options =
+        %{}
+        |> RequestOptions.build("/backend-api/codex/responses", payload)
+        |> RequestOptions.for_websocket(payload)
+
+      assert {:ok, encoded} =
+               PayloadNormalizer.upstream_payload(
+                 payload,
+                 %Model{upstream_model_id: "gpt-5.6"},
+                 "/backend-api/codex/responses",
+                 request_options
+               )
+
+      assert get_in(Jason.decode!(encoded), ["input", Access.at(0)]) == message
     end
 
     test "preserves malformed agent message content shapes while removing encrypted markers" do

--- a/test/codex_pooler_web/controllers/runtime/backend_codex_websocket_test.exs
+++ b/test/codex_pooler_web/controllers/runtime/backend_codex_websocket_test.exs
@@ -3178,7 +3178,7 @@ defmodule CodexPoolerWeb.Runtime.BackendCodexWebsocketTest do
     assert request.usage_status == "usage_known"
   end
 
-  test "websocket response.create strips mixed encrypted agent messages before upstream dispatch" do
+  test "websocket response.create preserves encrypted multi-agent messages for upstream dispatch" do
     upstream =
       start_upstream(
         FakeUpstream.json_response(%{
@@ -3209,7 +3209,11 @@ defmodule CodexPoolerWeb.Runtime.BackendCodexWebsocketTest do
                      "author" => "root",
                      "recipient" => "worker",
                      "content" => [
-                       %{"type" => "input_text", "text" => "Message Type: MESSAGE\nPayload:\n"},
+                       %{
+                         "type" => "input_text",
+                         "text" =>
+                           "Message Type: MESSAGE\nTask name: /root\nSender: /root/worker\nPayload:\n"
+                       },
                        %{
                          "type" => "encrypted_content",
                          "encrypted_content" => raw_agent_encrypted_content
@@ -3247,14 +3251,29 @@ defmodule CodexPoolerWeb.Runtime.BackendCodexWebsocketTest do
 
     assert Enum.map(captured.json["input"], &Map.fetch!(&1, "type")) == [
              "message",
+             "agent_message",
              "message",
              "agent_message"
            ]
 
-    assert captured.json["input"] |> Enum.at(1) |> Map.fetch!("encrypted_content")
+    assert captured.json["input"]
+           |> Enum.at(1)
+           |> Map.fetch!("content") == [
+             %{
+               "type" => "input_text",
+               "text" =>
+                 "Message Type: MESSAGE\nTask name: /root\nSender: /root/worker\nPayload:\n"
+             },
+             %{
+               "type" => "encrypted_content",
+               "encrypted_content" => raw_agent_encrypted_content
+             }
+           ]
+
+    assert captured.json["input"] |> Enum.at(2) |> Map.fetch!("encrypted_content")
 
     assert captured.json["input"]
-           |> Enum.at(2)
+           |> Enum.at(3)
            |> Map.fetch!("content")
            |> Enum.at(0)
            |> Map.fetch!("type") ==


### PR DESCRIPTION
## Summary

Preserve encrypted Codex multi-agent v2 handoffs when forwarding Responses requests over the Pooler WebSocket path.

Codex 0.146.0 represents inter-agent `NEW_TASK` and `MESSAGE` handoffs as an `agent_message` with two content parts:

1. a plaintext protocol envelope containing `Message Type`, `Task name`, `Sender`, and `Payload`;
2. the encrypted task/message payload.

The WebSocket normalizer removed the entire item because it contained `encrypted_content`. HTTP did not. As a result, the child thread was created but reached the model without its task.

The exception is deliberately narrow: it preserves only the exact two-part Codex v2 envelope for `NEW_TASK` and `MESSAGE`. Generic encrypted agent messages, incomplete lookalikes, encrypted tool-schema markers, and metadata redaction keep their existing behavior.

## Reproduction

A controlled native Codex A/B used:

- Codex CLI `0.146.0`;
- `gpt-5.6-sol`;
- the same Pooler provider and prompt;
- OmO disabled;
- only `supports_websockets` changed.

Before this fix:

- WebSocket: the child answered `What would you like me to work on?`;
- HTTP: the child returned the exact requested token, `NATIVE_HTTP_CHILD_OK`.

This isolates the lost task to the Pooler WebSocket normalization path rather than OmO or model tool use.

## Tests

- Added unit regressions for encrypted v2 `NEW_TASK` and `MESSAGE` forwarding.
- Added a negative regression for an incomplete encrypted lookalike.
- Updated the WebSocket dispatch test to assert the full envelope reaches the upstream request while ciphertext remains absent from persisted request/attempt metadata.

Verified on the current `origin/main` base:

- `mix compile --warnings-as-errors`
- `mix deps.unlock --check-unused`
- `mix format --check-formatted`
- `mix test test/codex_pooler/gateway/payloads test/codex_pooler_web/controllers/runtime/backend_codex_websocket_test.exs` — 318 passed
- `mix credo --strict`
- `mix sobelow --exit --threshold medium --skip`

A full local `mix test` run exceeded the 10-minute command limit and was terminated; it had not reported a test assertion failure before termination. CI should complete the full suite.