### PR TITLE
fix(streaming): preserve aggregate usage with large attribution

### DIFF
--- a/lib/codex_pooler/gateway/runtime/streaming/stream_usage_observer.ex
+++ b/lib/codex_pooler/gateway/runtime/streaming/stream_usage_observer.ex
@@ -4,6 +4,7 @@ defmodule CodexPooler.Gateway.Runtime.Streaming.StreamUsageObserver do
   alias CodexPooler.Gateway.Runtime.Finalization.ResponseUsage
 
   @max_candidate_bytes 16_384
+  @max_skipped_nesting 128
   @marker_suffix_bytes 64
   @usage_marker ~r/(?<!\\)"usage"\s*:/
   @service_tier_pattern ~r/(?<!\\)"service_tier"\s*:\s*"([^"\\]+)"/
@@ -11,10 +12,21 @@ defmodule CodexPooler.Gateway.Runtime.Streaming.StreamUsageObserver do
   @event_pattern ~r/(?:^|\n)event:\s*(response\.[^\r\n]+)/
   @event_prefix "event:"
 
+  @type sanitizer :: %{
+          required(:depth) => non_neg_integer(),
+          required(:escaped?) => boolean(),
+          required(:in_string?) => boolean(),
+          required(:key_position?) => boolean(),
+          required(:phase) =>
+            :normal | :after_attribution_key | :attribution_value | :skip | :invalid,
+          required(:skip_stack) => [integer()],
+          required(:string) => binary()
+        }
   @type candidate :: %{
           required(:buffer) => binary(),
           required(:event_prefix) => binary(),
           required(:event_type) => String.t() | nil,
+          required(:sanitizer) => sanitizer(),
           required(:service_tier) => String.t() | nil
         }
   @type t :: %{
@@ -79,12 +91,13 @@ defmodule CodexPooler.Gateway.Runtime.Streaming.StreamUsageObserver do
 
       :none ->
         {candidate_data, event_prefix} = split_event_prefix(scan)
+        {candidate, buffer} = append_candidate(candidate, candidate_data)
 
         inspect_candidate(%{
           state
           | candidate: %{
               candidate
-              | buffer: candidate.buffer <> candidate_data,
+              | buffer: buffer,
                 event_prefix: event_prefix
             }
         })
@@ -100,11 +113,16 @@ defmodule CodexPooler.Gateway.Runtime.Streaming.StreamUsageObserver do
         state = update_event_context(state, context)
 
         candidate = %{
-          buffer: binary_part(scan, offset, byte_size(scan) - offset),
+          buffer: "",
           event_prefix: "",
           event_type: state.event_type,
+          sanitizer: new_sanitizer(),
           service_tier: state.service_tier
         }
+
+        candidate_data = binary_part(scan, offset, byte_size(scan) - offset)
+        {candidate, buffer} = append_candidate(candidate, candidate_data)
+        candidate = %{candidate | buffer: buffer}
 
         inspect_candidate(%{state | candidate: candidate, marker_suffix: ""})
 
@@ -129,12 +147,188 @@ defmodule CodexPooler.Gateway.Runtime.Streaming.StreamUsageObserver do
     end
   end
 
+  defp bound_incomplete_candidate(
+         %{candidate: %{buffer: buffer, sanitizer: %{phase: :invalid}} = candidate} = state
+       ) do
+    %{state | candidate: %{candidate | buffer: suffix(buffer, @marker_suffix_bytes)}}
+  end
+
   defp bound_incomplete_candidate(%{candidate: %{buffer: buffer}} = state)
        when byte_size(buffer) > @max_candidate_bytes do
     %{state | candidate: nil, marker_suffix: suffix(buffer, @marker_suffix_bytes)}
   end
 
   defp bound_incomplete_candidate(state), do: state
+
+  defp append_candidate(candidate, data) do
+    {sanitizer, output} = sanitize_attribution(candidate.sanitizer, data)
+    {%{candidate | sanitizer: sanitizer}, candidate.buffer <> output}
+  end
+
+  defp new_sanitizer do
+    %{
+      depth: 0,
+      escaped?: false,
+      in_string?: false,
+      key_position?: false,
+      phase: :normal,
+      skip_stack: [],
+      string: ""
+    }
+  end
+
+  defp sanitize_attribution(sanitizer, data),
+    do: sanitize_attribution(sanitizer, data, [])
+
+  defp sanitize_attribution(sanitizer, "", output),
+    do: {sanitizer, output |> Enum.reverse() |> IO.iodata_to_binary()}
+
+  defp sanitize_attribution(%{phase: :invalid} = sanitizer, _data, output) do
+    sanitize_attribution(sanitizer, "", output)
+  end
+
+  defp sanitize_attribution(
+         %{phase: :after_attribution_key} = sanitizer,
+         <<byte, rest::binary>>,
+         output
+       ) do
+    cond do
+      byte in [32, 9, 10, 13] ->
+        sanitize_attribution(sanitizer, rest, [<<byte>> | output])
+
+      byte == ?: ->
+        sanitize_attribution(%{sanitizer | phase: :attribution_value}, rest, [":" | output])
+
+      true ->
+        sanitize_attribution(%{sanitizer | phase: :normal}, <<byte, rest::binary>>, output)
+    end
+  end
+
+  defp sanitize_attribution(
+         %{phase: :attribution_value} = sanitizer,
+         <<byte, rest::binary>>,
+         output
+       ) do
+    cond do
+      byte in [32, 9, 10, 13] ->
+        sanitize_attribution(sanitizer, rest, [<<byte>> | output])
+
+      byte == ?{ ->
+        sanitizer = %{sanitizer | phase: :skip, skip_stack: [?}], in_string?: false}
+        sanitize_attribution(sanitizer, rest, ["null" | output])
+
+      true ->
+        sanitize_attribution(%{sanitizer | phase: :normal}, <<byte, rest::binary>>, output)
+    end
+  end
+
+  defp sanitize_attribution(
+         %{phase: :skip, in_string?: true, escaped?: true} = sanitizer,
+         <<_byte, rest::binary>>,
+         output
+       ),
+       do: sanitize_attribution(%{sanitizer | escaped?: false}, rest, output)
+
+  defp sanitize_attribution(
+         %{phase: :skip, in_string?: true} = sanitizer,
+         <<byte, rest::binary>>,
+         output
+       ) do
+    sanitizer =
+      case byte do
+        ?\\ -> %{sanitizer | escaped?: true}
+        ?" -> %{sanitizer | in_string?: false}
+        _other -> sanitizer
+      end
+
+    sanitize_attribution(sanitizer, rest, output)
+  end
+
+  defp sanitize_attribution(
+         %{phase: :skip, skip_stack: stack} = sanitizer,
+         <<byte, rest::binary>>,
+         output
+       ) do
+    case {byte, stack} do
+      {?", _stack} ->
+        sanitize_attribution(%{sanitizer | in_string?: true}, rest, output)
+
+      {?{, _stack} ->
+        push_skipped_container(sanitizer, ?}, rest, output)
+
+      {?[, _stack} ->
+        push_skipped_container(sanitizer, ?], rest, output)
+
+      {closing, [closing]} ->
+        sanitize_attribution(%{sanitizer | phase: :normal, skip_stack: []}, rest, output)
+
+      {closing, [closing | remaining]} ->
+        sanitize_attribution(%{sanitizer | skip_stack: remaining}, rest, output)
+
+      {closing, _stack} when closing in [?}, ?]] ->
+        # Keep skipping malformed attribution so it cannot become valid aggregate usage.
+        sanitize_attribution(sanitizer, rest, output)
+
+      _other ->
+        sanitize_attribution(sanitizer, rest, output)
+    end
+  end
+
+  defp sanitize_attribution(
+         %{in_string?: true, escaped?: true} = sanitizer,
+         <<byte, rest::binary>>,
+         output
+       ) do
+    string = append_key_byte(sanitizer.string, byte)
+
+    sanitize_attribution(%{sanitizer | escaped?: false, string: string}, rest, [<<byte>> | output])
+  end
+
+  defp sanitize_attribution(%{in_string?: true} = sanitizer, <<byte, rest::binary>>, output) do
+    case byte do
+      ?\\ ->
+        sanitize_attribution(%{sanitizer | escaped?: true}, rest, ["\\" | output])
+
+      ?" ->
+        phase =
+          if sanitizer.key_position? and sanitizer.depth == 1 and
+               sanitizer.string == "attribution",
+             do: :after_attribution_key,
+             else: :normal
+
+        sanitizer = %{sanitizer | in_string?: false, phase: phase, string: ""}
+        sanitize_attribution(sanitizer, rest, ["\"" | output])
+
+      _other ->
+        string = append_key_byte(sanitizer.string, byte)
+        sanitize_attribution(%{sanitizer | string: string}, rest, [<<byte>> | output])
+    end
+  end
+
+  defp sanitize_attribution(%{phase: :normal} = sanitizer, <<byte, rest::binary>>, output) do
+    sanitizer =
+      case byte do
+        ?" -> %{sanitizer | in_string?: true, string: ""}
+        ?{ -> %{sanitizer | depth: sanitizer.depth + 1, key_position?: sanitizer.depth == 0}
+        ?} -> %{sanitizer | depth: max(sanitizer.depth - 1, 0), key_position?: false}
+        ?, -> %{sanitizer | key_position?: sanitizer.depth == 1}
+        byte when byte in [32, 9, 10, 13] -> sanitizer
+        _other -> %{sanitizer | key_position?: false}
+      end
+
+    sanitize_attribution(sanitizer, rest, [<<byte>> | output])
+  end
+
+  defp append_key_byte(string, byte) when byte_size(string) < 32, do: string <> <<byte>>
+  defp append_key_byte(string, _byte), do: string
+
+  defp push_skipped_container(%{skip_stack: stack} = sanitizer, closing, rest, output) do
+    if length(stack) < @max_skipped_nesting do
+      sanitize_attribution(%{sanitizer | skip_stack: [closing | stack]}, rest, output)
+    else
+      sanitize_attribution(%{sanitizer | phase: :invalid, skip_stack: []}, rest, output)
+    end
+  end
 
   defp maybe_accept_candidate(state, candidate, usage_object)
        when byte_size(usage_object) <= @max_candidate_bytes,

--- a/test/codex_pooler/gateway/runtime/streaming/stream_usage_observer_test.exs
+++ b/test/codex_pooler/gateway/runtime/streaming/stream_usage_observer_test.exs
@@ -110,6 +110,187 @@ defmodule CodexPooler.Gateway.Runtime.Streaming.StreamUsageObserverTest do
     assert StreamUsageObserver.candidate_bytes(state) <= StreamUsageObserver.max_candidate_bytes()
   end
 
+  test "captures aggregate usage around attribution larger than observer and retained-body limits" do
+    for order <- [:attribution_first, :attribution_last] do
+      event = large_attribution_event(order)
+
+      state =
+        event
+        |> variable_chunks([1, 2, 7, 31, 257, 4_093])
+        |> Enum.reduce(StreamUsageObserver.new(), &StreamUsageObserver.observe(&2, &1))
+
+      retained =
+        RetainedBody.empty()
+        |> RetainedBody.append(event)
+        |> RetainedBody.read()
+
+      assert byte_size(event) > RetainedBody.max_bytes()
+      assert ResponseUsage.from_sse(retained)[:status] == "usage_unknown"
+
+      assert StreamUsageObserver.usage(state) == %{
+               @known_usage
+               | input_tokens: 2_414,
+                 cached_input_tokens: 1_337,
+                 output_tokens: 5,
+                 reasoning_tokens: 3,
+                 total_tokens: 2_419
+             }
+
+      assert StreamUsageObserver.candidate_bytes(state) == 0
+    end
+  end
+
+  test "skips braces and escaped quotes inside large attribution strings across chunk boundaries" do
+    escaped = String.duplicate(~s(value \\"quoted} { text), 5_000)
+    event = large_attribution_event(:attribution_first, escaped)
+
+    state =
+      event
+      |> variable_chunks([3, 1, 5, 2, 89])
+      |> Enum.reduce(StreamUsageObserver.new(), &StreamUsageObserver.observe(&2, &1))
+
+    assert StreamUsageObserver.usage(state).total_tokens == 2_419
+    assert StreamUsageObserver.usage(state).cached_input_tokens == 1_337
+  end
+
+  test "rejects valid attribution beyond nesting limit and recovers at the next event" do
+    nested_usage =
+      Jason.encode!(%{
+        "usage" => usage(100, 1, 101),
+        "tail" => String.duplicate("x", 20_000)
+      })
+
+    attribution =
+      String.duplicate(~s({"nested":), 130) <> nested_usage <> String.duplicate("}", 130)
+
+    event = large_attribution_event(:attribution_first, nil, 2_419, attribution)
+    {split_at, _length} = event |> :binary.matches(~s("usage":)) |> List.last()
+    <<first::binary-size(^split_at), second::binary>> = event
+
+    state =
+      StreamUsageObserver.new()
+      |> StreamUsageObserver.observe(first)
+      |> StreamUsageObserver.observe(second)
+
+    assert StreamUsageObserver.usage(state) == nil
+    assert StreamUsageObserver.candidate_bytes(state) <= StreamUsageObserver.max_candidate_bytes()
+
+    recovered =
+      StreamUsageObserver.observe(
+        state,
+        usage_event("response.completed", usage(16, 5, 21), "priority")
+      )
+
+    assert StreamUsageObserver.usage(recovered) == @known_usage
+  end
+
+  test "rejects malformed mixed-container overflow at every split and recovers" do
+    attribution =
+      "{" <>
+        String.duplicate(~s("nested":{), 128) <>
+        "0]" <> String.duplicate("}", 128)
+
+    malformed = large_attribution_event(:attribution_first, nil, 2_419, attribution)
+    valid = usage_event("response.completed", usage(16, 5, 21), "priority")
+
+    for split_at <- 0..byte_size(malformed) do
+      <<first::binary-size(^split_at), second::binary>> = malformed
+
+      state =
+        StreamUsageObserver.new()
+        |> StreamUsageObserver.observe(first)
+        |> StreamUsageObserver.observe(second)
+
+      assert StreamUsageObserver.usage(state) == nil
+
+      assert StreamUsageObserver.candidate_bytes(state) <=
+               StreamUsageObserver.max_candidate_bytes()
+
+      assert state
+             |> StreamUsageObserver.observe(valid)
+             |> StreamUsageObserver.usage() == @known_usage
+    end
+  end
+
+  test "bounds a large same-chunk prefix before invalid attribution and recovers" do
+    attribution =
+      String.duplicate(~s({"nested":), 129) <>
+        Jason.encode!(%{"usage" => usage(100, 1, 101)}) <>
+        String.duplicate("}", 129)
+
+    malformed =
+      large_attribution_event(:attribution_last, nil, 2_419, attribution)
+      |> String.replace(
+        ~s("input_tokens":2414),
+        ~s("padding":"#{String.duplicate("x", StreamUsageObserver.max_candidate_bytes())}","input_tokens":2414),
+        global: false
+      )
+
+    invalid_state = StreamUsageObserver.observe(StreamUsageObserver.new(), malformed)
+
+    assert StreamUsageObserver.usage(invalid_state) == nil
+    refute invalid_state.terminal?
+
+    assert StreamUsageObserver.candidate_bytes(invalid_state) <=
+             StreamUsageObserver.max_candidate_bytes()
+
+    valid = usage_event("response.completed", usage(16, 5, 21), "priority")
+
+    for split_at <- 0..byte_size("event:") do
+      <<first::binary-size(^split_at), second::binary>> = valid
+
+      recovered =
+        invalid_state
+        |> StreamUsageObserver.observe(first)
+        |> StreamUsageObserver.observe(second)
+
+      assert StreamUsageObserver.usage(recovered) == @known_usage
+      assert recovered.terminal?
+      assert StreamUsageObserver.candidate_bytes(recovered) == 0
+    end
+  end
+
+  test "captures oversized attribution across every attribution marker boundary" do
+    event = large_attribution_event(:attribution_first)
+    attribution_offset = marker_offset(event, ~s("attribution"))
+
+    for split_at <- attribution_offset..(attribution_offset + byte_size(~s("attribution"))) do
+      <<first::binary-size(^split_at), second::binary>> = event
+
+      state =
+        StreamUsageObserver.new()
+        |> StreamUsageObserver.observe(first)
+        |> StreamUsageObserver.observe(second)
+
+      assert StreamUsageObserver.usage(state).total_tokens == 2_419
+      assert StreamUsageObserver.candidate_bytes(state) == 0
+    end
+  end
+
+  test "rejects malformed large attribution and invalid aggregate totals" do
+    malformed =
+      large_attribution_event(:attribution_first)
+      |> String.replace(~s("input_tokens":2414), ~s("input_tokens" 2414), global: false)
+
+    invalid_total = large_attribution_event(:attribution_last, nil, 2_418)
+
+    negative =
+      large_attribution_event(:attribution_first)
+      |> String.replace(~s("input_tokens":2414), ~s("input_tokens":-1), global: false)
+
+    for event <- [malformed, invalid_total, negative] do
+      state =
+        event
+        |> variable_chunks([1, 127, 4_097])
+        |> Enum.reduce(StreamUsageObserver.new(), &StreamUsageObserver.observe(&2, &1))
+
+      assert StreamUsageObserver.usage(state) == nil
+
+      assert StreamUsageObserver.candidate_bytes(state) <=
+               StreamUsageObserver.max_candidate_bytes()
+    end
+  end
+
   test "abandons a truncated usage candidate when the next explicit event begins" do
     truncated =
       ~s(event: response.in_progress\ndata: {"type":"response.in_progress","usage":{"padding":") <>
@@ -305,6 +486,57 @@ defmodule CodexPooler.Gateway.Runtime.Streaming.StreamUsageObserverTest do
       "reasoning_tokens" => 0,
       "total_tokens" => total
     }
+  end
+
+  defp large_attribution_event(order, text \\ nil, total \\ 2_419, encoded_attribution \\ nil) do
+    encoded_attribution =
+      encoded_attribution ||
+        Jason.encode!(%{
+          "items" =>
+            Enum.map(1..400, fn index ->
+              %{
+                "id" => "item-#{index}",
+                "input_tokens" => index,
+                "metadata" => %{
+                  "text" => text || String.duplicate("attribution payload", 40),
+                  "nested" => [%{"brace" => "}"}, "{"]
+                }
+              }
+            end)
+        })
+
+    fields = [
+      ~s("input_tokens":2414),
+      ~s("input_tokens_details":{"cached_tokens":1337}),
+      ~s("output_tokens":5),
+      ~s("output_tokens_details":{"reasoning_tokens":3}),
+      ~s("total_tokens":#{total})
+    ]
+
+    usage_fields =
+      case order do
+        :attribution_first -> [~s("attribution":#{encoded_attribution}) | fields]
+        :attribution_last -> fields ++ [~s("attribution":#{encoded_attribution})]
+      end
+
+    payload =
+      ~s({"type":"response.completed","response":{"service_tier":"priority","usage":{) <>
+        Enum.join(usage_fields, ",") <> ~s(}}})
+
+    "event: response.completed\ndata: " <> payload <> "\n\n"
+  end
+
+  defp variable_chunks(binary, sizes), do: variable_chunks(binary, sizes, sizes, [])
+
+  defp variable_chunks("", _sizes, _all_sizes, chunks), do: Enum.reverse(chunks)
+
+  defp variable_chunks(binary, [], all_sizes, chunks),
+    do: variable_chunks(binary, all_sizes, all_sizes, chunks)
+
+  defp variable_chunks(binary, [size | sizes], all_sizes, chunks) do
+    size = min(size, byte_size(binary))
+    <<chunk::binary-size(^size), rest::binary>> = binary
+    variable_chunks(rest, sizes, all_sizes, [chunk | chunks])
   end
 
   defp sse_event(event, payload) do


### PR DESCRIPTION
## Problem
Large optional usage attribution exceeds the observer's16 KiB candidate cap and the64 KiB fallback suffix. Exact request-ID live reproduction returned valid2414 input/5 output tokens to the client while settlement recorded unknown usage and8431 estimated input tokens. See #347.

## Solution
Skip optional top-level attribution incrementally, retaining aggregate counters for existing JSON/token validation. Keep the existing candidate cap. Reject nesting beyond128 tracked containers and retain only64 bytes for explicit SSE boundary recovery. Do not rescan rejected attribution for nested usage keys.

## Scope
Observer and adjacent tests only. No accounting policy, database, routing, model or production configuration changes.

## Validation
- Actual-source isolated observer + ResponseUsage tests:52 passed using Elixir1.20.2/OTP28 Docker image.
- Red regressions demonstrated each repaired defect before correction.
- Focused mix format --check-formatted and git diff --check passed.
- Final independent incremental review: zero medium-or-higher findings. BEAM backing-storage probe confirmed a64-byte suffix retains64 bytes, not its1 MB parent.
- Canonical PostgreSQL-backed mix test was not run successfully locally; PostgreSQL was unavailable. Isolated suites compile/use actual project modules, not a translated parser.
- No production deployment or corrected live inference test performed.

## Risk
Excessively deep attribution now yields unknown usage safely. Full integration CI remains necessary.

## Review record
Standard tier, GJC investigative/direct implementation and first-wave correctness + quality/contract reviews. Three repair rounds resolved nested usage acceptance, malformed overflow acceptance and rejected-candidate memory retention. Final incremental review passed.

## Notes / accepted debt
No unresolved medium+ findings. Canonical database-backed validation remains pending. Hermes event attachment capacity blocked tools; Grant approved raw GJC CLI fallback. No caps raised.

## Attribution and provenance
Implemented and reviewed using GJC investigative preset; parent orchestration by OpenAI GPT-6 Astra. No more precise executor model assertion.
Base:fcdb1f83ed9dad4f8aed7e48f5203616ac2d480f
Head:ff715de45f7f21a672d837d78c7ac9ff595f924a
Local frozen plan:~/.hermes/plans/codex-pooler/2026-09-05-large-usage-attribution.md
Plan SHA-256:944389b67d888a86515214b93475cfe4b03da307d8a0180bee7be0878dbaf854
PR intentionally open and unmerged.

Fixes #347
