### PR TITLE
fix: expose conflicting quota source observations in admin meters

### DIFF
--- a/lib/codex_pooler/quotas/evidence/codex_parsers.ex
+++ b/lib/codex_pooler/quotas/evidence/codex_parsers.ex
@@ -437,6 +437,15 @@ defmodule CodexPooler.Quotas.Evidence.CodexParsers do
       ]
     end
     |> Enum.reject(&is_nil/1)
+    |> Enum.map(fn attrs ->
+      # Keep the provider's descriptor without changing the routing identity.
+      Map.update!(attrs, :metadata, fn metadata ->
+        Map.merge(
+          metadata,
+          compact_metadata(%{"normal_model_slug" => present_string(limit["normal_model_slug"])})
+        )
+      end)
+    end)
   end
 
   defp additional_limit_evidence(_limit, _observed_at, _validation), do: []

--- a/lib/codex_pooler/upstreams/quota/window_selector.ex
+++ b/lib/codex_pooler/upstreams/quota/window_selector.ex
@@ -76,16 +76,10 @@ defmodule CodexPooler.Upstreams.Quota.WindowSelector do
     end
   end
 
-  # A fresh sibling whose reset lies a full margin beyond a STALE row's reset
-  # proves the provider started a new cycle after that row was last observed:
-  # rows still describing the ended cycle must not compete for selection, or
-  # their pessimistic pressure keeps winning the merge and masks the restart
-  # from operators and routing alike (observed live: a stale rate-limit-event
-  # row at 94 percent from the ended cycle displayed as 6 percent remaining
-  # while the account was genuinely unused). Fresh rows are never rejected —
-  # same-cycle resets legitimately drift up to the window's own duration across
-  # provider surfaces — and groups without any fresh reset-bearing row are left
-  # untouched, so an all-stale exhausted group keeps its fail-closed pessimism.
+  # Compatibility heuristic for routing selection, not proof of a new cycle:
+  # provider resets can disagree while both are still in the future. Preserve
+  # the existing routing decision here; the operator UI separately projects raw
+  # evidence and exposes these disagreements without claiming either is truth.
   @prior_cycle_margin_seconds 60 * 60
 
   defp reject_prior_cycle_windows(candidates, as_of) do

--- a/lib/codex_pooler_web/live/admin/components/pages/upstreams/account_card.ex
+++ b/lib/codex_pooler_web/live/admin/components/pages/upstreams/account_card.ex
@@ -963,6 +963,8 @@ defmodule CodexPoolerWeb.Admin.UpstreamPageComponents.AccountCard do
 
   defp reported_quota_limits(_quota_limits), do: []
 
+  defp reported_quota_limit?(%{source_disagreement: true}), do: true
+  defp reported_quota_limit?(%{reset_disagreement: true}), do: true
   defp reported_quota_limit?(%{percent: %Decimal{}}), do: true
 
   defp reported_quota_limit?(%{reset_label: reset_label}) when is_binary(reset_label),

--- a/lib/codex_pooler_web/live/admin/components/pages/upstreams/account_card/quota_limit_row.ex
+++ b/lib/codex_pooler_web/live/admin/components/pages/upstreams/account_card/quota_limit_row.ex
@@ -32,6 +32,13 @@ defmodule CodexPoolerWeb.Admin.UpstreamPageComponents.AccountCard.QuotaLimitRow 
         )} remaining
         ({Map.get(@limit, :selected_source)}).
       </p>
+      <p
+        :if={Map.get(@limit, :reset_disagreement, false)}
+        class="text-xs text-warning"
+        data-role="quota-reset-disagreement"
+      >
+        Reset reports differ; no single reset is confirmed.
+      </p>
       <progress
         id={"#{@id}-progress"}
         data-role="upstream-limit-progress"
@@ -80,7 +87,9 @@ defmodule CodexPoolerWeb.Admin.UpstreamPageComponents.AccountCard.QuotaLimitRow 
       </div>
       <details
         :if={Map.get(@limit, :observations, []) != []}
-        open={Map.get(@limit, :source_disagreement, false)}
+        open={
+          Map.get(@limit, :source_disagreement, false) or Map.get(@limit, :reset_disagreement, false)
+        }
         class="text-[11px]"
         data-role="quota-source-observations"
       >

--- a/lib/codex_pooler_web/live/admin/components/pages/upstreams/account_card/quota_limit_row.ex
+++ b/lib/codex_pooler_web/live/admin/components/pages/upstreams/account_card/quota_limit_row.ex
@@ -21,6 +21,17 @@ defmodule CodexPoolerWeb.Admin.UpstreamPageComponents.AccountCard.QuotaLimitRow 
         </span>
         <span class={[quota_limit_percent_class(@limit), "shrink-0"]}>{@limit.percent_label}</span>
       </div>
+      <p
+        :if={Map.get(@limit, :source_disagreement, false)}
+        data-role="quota-source-disagreement"
+        class="text-xs text-warning"
+      >
+        Sources disagree; remaining quota is uncertain. Routing currently selects {Map.get(
+          @limit,
+          :selected_percent_label
+        )} remaining
+        ({Map.get(@limit, :selected_source)}).
+      </p>
       <progress
         id={"#{@id}-progress"}
         data-role="upstream-limit-progress"
@@ -64,6 +75,34 @@ defmodule CodexPoolerWeb.Admin.UpstreamPageComponents.AccountCard.QuotaLimitRow 
           <span data-role="relative-countdown-value">{strip_in_prefix(@limit.reset_label)}</span>
         </span>
       </div>
+      <div class="text-[11px] text-base-content/60" data-role="quota-evidence-age">
+        {Map.get(@limit, :freshness_label)} · {Map.get(@limit, :observed_label)}
+      </div>
+      <details
+        :if={Map.get(@limit, :observations, []) != []}
+        open={Map.get(@limit, :source_disagreement, false)}
+        class="text-[11px]"
+        data-role="quota-source-observations"
+      >
+        <summary class="cursor-pointer">Source observations (UTC)</summary>
+        <ul class="mt-1 grid gap-2">
+          <li
+            :for={observation <- Map.get(@limit, :observations, [])}
+            class="break-words"
+            data-source={observation.source}
+            data-freshness={observation.freshness}
+          >
+            <div>
+              {observation.source}: {observation.used} used / {observation.remaining} remaining
+            </div>
+            <div>
+              {observation.freshness}{if observation.elapsed, do: "; window elapsed", else: ""}
+            </div>
+            <div>Observed {observation.observed_at}; reset {observation.reset_at}</div>
+            <div :if={observation.descriptor != ""}>{observation.descriptor}</div>
+          </li>
+        </ul>
+      </details>
     </div>
     """
   end

--- a/lib/codex_pooler_web/live/admin/components/pages/upstreams/cockpit/charts.ex
+++ b/lib/codex_pooler_web/live/admin/components/pages/upstreams/cockpit/charts.ex
@@ -338,6 +338,8 @@ defmodule CodexPoolerWeb.Admin.UpstreamCockpitComponents.Charts do
 
   defp reported_quota_limits(_quota_limits), do: []
 
+  defp reported_quota_limit?(%{source_disagreement: true}), do: true
+  defp reported_quota_limit?(%{reset_disagreement: true}), do: true
   defp reported_quota_limit?(%{percent: %Decimal{}}), do: true
   defp reported_quota_limit?(%{reset_label: reset_label}) when is_binary(reset_label), do: true
   defp reported_quota_limit?(%{count_label: count_label}) when is_binary(count_label), do: true

--- a/lib/codex_pooler_web/live/admin/read_models/upstream_accounts_read_model.ex
+++ b/lib/codex_pooler_web/live/admin/read_models/upstream_accounts_read_model.ex
@@ -464,7 +464,8 @@ defmodule CodexPoolerWeb.Admin.UpstreamAccountsReadModel do
           quota_windows,
           datetime_preferences,
           snapshot_at,
-          quota_snapshot.credit_balance
+          quota_snapshot.credit_balance,
+          raw_quota_windows
         ),
       identity_observability: identity_observability
     }

--- a/lib/codex_pooler_web/live/admin/read_models/upstream_accounts_read_model/quota_observations.ex
+++ b/lib/codex_pooler_web/live/admin/read_models/upstream_accounts_read_model/quota_observations.ex
@@ -11,6 +11,10 @@ defmodule CodexPoolerWeb.Admin.UpstreamAccountsReadModel.QuotaObservations do
   alias CodexPooler.Upstreams.Quota.AccountQuotaWindow
   alias CodexPooler.Upstreams.Quota.WindowSelector
 
+  # Presentation tolerance for timestamp rounding and collection delay. This
+  # does not identify quota cycles or change source timestamps/routing policy.
+  @reset_display_tolerance_seconds 60
+
   def key(%AccountQuotaWindow{window_kind: "primary", window_minutes: 10_080} = window),
     do: key(%{window | window_kind: "secondary"})
 
@@ -104,10 +108,29 @@ defmodule CodexPoolerWeb.Admin.UpstreamAccountsReadModel.QuotaObservations do
     end)
   end
 
-  defp different_report?(left, right, :usage),
-    do: not Decimal.equal?(left.used_percent, right.used_percent)
+  defp different_report?(left, right, :usage) do
+    # Usage can grow between samples. A decrease before either reported window
+    # ends is uncertain, even if the newer source reports a later reset.
+    case observation_order(left.observed_at, right.observed_at) do
+      :lt -> Decimal.compare(left.used_percent, right.used_percent) == :gt
+      :gt -> Decimal.compare(right.used_percent, left.used_percent) == :gt
+      _same_or_unknown -> not Decimal.equal?(left.used_percent, right.used_percent)
+    end
+  end
 
-  defp different_report?(left, right, :reset), do: left.reset_at != right.reset_at
+  defp different_report?(
+         %{reset_at: %DateTime{} = left},
+         %{reset_at: %DateTime{} = right},
+         :reset
+       ),
+       do: abs(DateTime.diff(left, right, :second)) > @reset_display_tolerance_seconds
+
+  defp different_report?(_left, _right, :reset), do: false
+
+  defp observation_order(%DateTime{} = left, %DateTime{} = right),
+    do: DateTime.compare(left, right)
+
+  defp observation_order(_left, _right), do: :unknown
 
   defp descriptor(window) do
     [

--- a/lib/codex_pooler_web/live/admin/read_models/upstream_accounts_read_model/quota_observations.ex
+++ b/lib/codex_pooler_web/live/admin/read_models/upstream_accounts_read_model/quota_observations.ex
@@ -32,14 +32,17 @@ defmodule CodexPoolerWeb.Admin.UpstreamAccountsReadModel.QuotaObservations do
 
   defp attach_row(row, groups, as_of) do
     windows = Map.get(groups, Map.get(row, :evidence_key), [])
-    disagreement? = disagreement?(windows, as_of)
+    disagreement? = disagreement?(windows, as_of, :usage)
+    reset_disagreement? = disagreement?(windows, as_of, :reset)
 
     row
     |> Map.put(:observations, observations(windows, as_of))
     |> Map.put(:source_disagreement, disagreement?)
+    |> Map.put(:reset_disagreement, reset_disagreement?)
     |> Map.put(:selected_percent_label, row.percent_label)
     |> Map.update!(:label, &scope_label(row.key, &1))
     |> mark_disagreement(disagreement?)
+    |> mark_reset_disagreement(reset_disagreement?)
   end
 
   defp scope_label(:weekly, label), do: "Account #{label}"
@@ -53,7 +56,14 @@ defmodule CodexPoolerWeb.Admin.UpstreamAccountsReadModel.QuotaObservations do
       percent: nil,
       percent_value: 0,
       percent_label: "sources differ",
-      meter_state: :unknown,
+      meter_state: :unknown
+    })
+  end
+
+  defp mark_reset_disagreement(row, false), do: row
+
+  defp mark_reset_disagreement(row, true) do
+    Map.merge(row, %{
       reset_at: nil,
       reset_label: nil,
       reset_title: nil,
@@ -79,7 +89,7 @@ defmodule CodexPoolerWeb.Admin.UpstreamAccountsReadModel.QuotaObservations do
     end)
   end
 
-  defp disagreement?(windows, as_of) do
+  defp disagreement?(windows, as_of, dimension) do
     current =
       Enum.filter(windows, fn window ->
         not Evidence.expired?(window, as_of) and match?(%Decimal{}, window.used_percent)
@@ -89,11 +99,15 @@ defmodule CodexPoolerWeb.Admin.UpstreamAccountsReadModel.QuotaObservations do
     |> Enum.any?(fn left ->
       Enum.any?(current, fn right ->
         left.source != right.source and
-          (not Decimal.equal?(left.used_percent, right.used_percent) or
-             left.reset_at != right.reset_at)
+          different_report?(left, right, dimension)
       end)
     end)
   end
+
+  defp different_report?(left, right, :usage),
+    do: not Decimal.equal?(left.used_percent, right.used_percent)
+
+  defp different_report?(left, right, :reset), do: left.reset_at != right.reset_at
 
   defp descriptor(window) do
     [

--- a/lib/codex_pooler_web/live/admin/read_models/upstream_accounts_read_model/quota_observations.ex
+++ b/lib/codex_pooler_web/live/admin/read_models/upstream_accounts_read_model/quota_observations.ex
@@ -1,0 +1,120 @@
+defmodule CodexPoolerWeb.Admin.UpstreamAccountsReadModel.QuotaObservations do
+  @moduledoc """
+  Operator evidence view. It never selects a routing window or updates evidence.
+
+  Different future resets do not prove rollover. Keep competing source reports,
+  with their original timestamps and current TTL state, until their windows end.
+  Even a fresh report is an observation, not independently verified capacity.
+  """
+
+  alias CodexPooler.Quotas.Evidence
+  alias CodexPooler.Upstreams.Quota.AccountQuotaWindow
+  alias CodexPooler.Upstreams.Quota.WindowSelector
+
+  def key(%AccountQuotaWindow{window_kind: "primary", window_minutes: 10_080} = window),
+    do: key(%{window | window_kind: "secondary"})
+
+  def key(window) do
+    {WindowSelector.logical_key(window), Evidence.additional_meter_token(window)}
+    |> :erlang.term_to_binary()
+    |> then(&:crypto.hash(:sha256, "quota-observation-group-v1:" <> &1))
+    |> Base.encode16(case: :lower)
+  end
+
+  def attach(rows, raw_windows, as_of) do
+    groups =
+      raw_windows
+      |> Enum.reject(&future_observation?(&1, as_of))
+      |> Enum.group_by(&key/1)
+
+    Enum.map(rows, &attach_row(&1, groups, as_of))
+  end
+
+  defp attach_row(row, groups, as_of) do
+    windows = Map.get(groups, Map.get(row, :evidence_key), [])
+    disagreement? = disagreement?(windows, as_of)
+
+    row
+    |> Map.put(:observations, observations(windows, as_of))
+    |> Map.put(:source_disagreement, disagreement?)
+    |> Map.put(:selected_percent_label, row.percent_label)
+    |> Map.update!(:label, &scope_label(row.key, &1))
+    |> mark_disagreement(disagreement?)
+  end
+
+  defp scope_label(:weekly, label), do: "Account #{label}"
+
+  defp scope_label(_key, label), do: label
+
+  defp mark_disagreement(row, false), do: row
+
+  defp mark_disagreement(row, true) do
+    Map.merge(row, %{
+      percent: nil,
+      percent_value: 0,
+      percent_label: "sources differ",
+      meter_state: :unknown,
+      reset_at: nil,
+      reset_label: nil,
+      reset_title: nil,
+      reset_semantics: :unknown,
+      reset_display_state: :absent
+    })
+  end
+
+  defp observations(windows, as_of) do
+    windows
+    |> Enum.sort_by(&{&1.source || "", iso8601(&1.observed_at), iso8601(&1.reset_at)})
+    |> Enum.map(fn window ->
+      %{
+        source: window.source || "source not reported",
+        observed_at: iso8601(window.observed_at),
+        reset_at: iso8601(window.reset_at),
+        freshness: Evidence.current_freshness_state(window, as_of),
+        elapsed: Evidence.expired?(window, as_of),
+        used: percent(window.used_percent),
+        remaining: remaining(window.used_percent),
+        descriptor: descriptor(window)
+      }
+    end)
+  end
+
+  defp disagreement?(windows, as_of) do
+    current =
+      Enum.filter(windows, fn window ->
+        not Evidence.expired?(window, as_of) and match?(%Decimal{}, window.used_percent)
+      end)
+
+    current
+    |> Enum.any?(fn left ->
+      Enum.any?(current, fn right ->
+        left.source != right.source and
+          (not Decimal.equal?(left.used_percent, right.used_percent) or
+             left.reset_at != right.reset_at)
+      end)
+    end)
+  end
+
+  defp descriptor(window) do
+    [
+      window.model,
+      window.upstream_model,
+      Map.get(window.metadata || %{}, "normal_model_slug")
+    ]
+    |> Enum.filter(&(is_binary(&1) and &1 != ""))
+    |> Enum.uniq()
+    |> Enum.join(" · ")
+  end
+
+  defp future_observation?(%{observed_at: %DateTime{} = observed_at}, as_of),
+    do: DateTime.compare(observed_at, as_of) == :gt
+
+  defp future_observation?(_window, _as_of), do: false
+
+  defp percent(%Decimal{} = value), do: "#{Decimal.to_string(value, :normal)}%"
+  defp percent(_value), do: "not reported"
+  defp remaining(%Decimal{} = used), do: percent(Decimal.sub(100, used))
+  defp remaining(_used), do: "not reported"
+  defp iso8601(%DateTime{} = time), do: DateTime.to_iso8601(time)
+  defp iso8601(_time), do: "not reported"
+end

--- a/lib/codex_pooler_web/live/admin/read_models/upstream_accounts_read_model/quota_projection.ex
+++ b/lib/codex_pooler_web/live/admin/read_models/upstream_accounts_read_model/quota_projection.ex
@@ -9,6 +9,7 @@ defmodule CodexPoolerWeb.Admin.UpstreamAccountsReadModel.QuotaProjection do
   alias CodexPooler.Upstreams.Quota.RoutingQuotaSnapshot
   alias CodexPooler.Upstreams.Quota.WindowSelector
   alias CodexPoolerWeb.Admin.UpstreamAccountsReadModel.Formatting
+  alias CodexPoolerWeb.Admin.UpstreamAccountsReadModel.QuotaObservations
   alias CodexPoolerWeb.Admin.UpstreamAccountsReadModel.SavedResetConfirmationProjection
   alias CodexPoolerWeb.DateTimeDisplay
   alias CodexPoolerWeb.RelativeTime
@@ -213,6 +214,13 @@ defmodule CodexPoolerWeb.Admin.UpstreamAccountsReadModel.QuotaProjection do
     windows
     |> quota_limit_rows(datetime_preferences, snapshot_at)
     |> Enum.map(&put_account_credit_balance(&1, windows, snapshot_at, credit_balance))
+  end
+
+  @doc "Projects raw observations separately from the unchanged routing selection."
+  def quota_limit_rows(windows, datetime_preferences, snapshot_at, credit_balance, raw_windows) do
+    windows
+    |> quota_limit_rows(datetime_preferences, snapshot_at, credit_balance)
+    |> QuotaObservations.attach(raw_windows, snapshot_at)
   end
 
   defp put_account_credit_balance(%{key: key} = row, windows, snapshot_at, credit_balance)
@@ -507,6 +515,8 @@ defmodule CodexPoolerWeb.Admin.UpstreamAccountsReadModel.QuotaProjection do
 
     %{
       key: key,
+      evidence_key: QuotaObservations.key(window),
+      selected_source: window.source,
       label: label,
       percent: remaining_percent,
       percent_value: quota_percent_value(remaining_percent),

--- a/test/codex_pooler/dev/seeds_test.exs
+++ b/test/codex_pooler/dev/seeds_test.exs
@@ -269,7 +269,7 @@ defmodule CodexPooler.Dev.SeedsTest do
     quota_labels = upstream_accounts |> Enum.flat_map(& &1.quota_limits) |> Enum.map(& &1.label)
 
     assert "5h" in quota_labels
-    assert "Weekly" in quota_labels
+    assert "Account Weekly" in quota_labels
     refute Enum.any?(quota_labels, &String.contains?(String.downcase(&1), "account primary"))
     refute Enum.any?(quota_labels, &String.contains?(String.downcase(&1), "account 5h"))
 

--- a/test/codex_pooler/upstreams/reconciliation/credit_balance_reconciliation_test.exs
+++ b/test/codex_pooler/upstreams/reconciliation/credit_balance_reconciliation_test.exs
@@ -146,8 +146,20 @@ defmodule CodexPooler.Upstreams.Reconciliation.CreditBalanceReconciliationTest d
     render_click(cockpit_view, "refresh_data")
     refute has_element?(list_view, "#upstream-account-#{identity.id}-limit-weekly-count")
     refute has_element?(cockpit_view, "#upstream-quota-limit-weekly-count")
-    assert has_element?(list_view, "#upstream-account-#{identity.id}-limit-weekly-reset")
-    assert has_element?(cockpit_view, "#upstream-quota-limit-weekly-reset")
+    # Distinct unelapsed provider resets and usage reports remain visible after
+    # credit counts disappear; neither parent may hide the uncertain quota row.
+    refute has_element?(list_view, "#upstream-account-#{identity.id}-limit-weekly-reset")
+    refute has_element?(cockpit_view, "#upstream-quota-limit-weekly-reset")
+
+    for {view, selector} <- [
+          {list_view, "#upstream-account-#{identity.id}-limit-weekly"},
+          {cockpit_view, "#upstream-quota-limit-weekly"}
+        ] do
+      assert has_element?(view, "#{selector} [data-role='quota-source-disagreement']")
+      assert has_element?(view, "#{selector} [data-role='quota-reset-disagreement']")
+      assert has_element?(view, "#{selector} [data-source='codex_usage_api']")
+      assert has_element?(view, "#{selector} [data-source='codex_rate_limit_event']")
+    end
 
     for malformed <- [nil, "invalid", %{"version" => 99}] do
       changed

--- a/test/codex_pooler/upstreams/reconciliation/credit_balance_reconciliation_test.exs
+++ b/test/codex_pooler/upstreams/reconciliation/credit_balance_reconciliation_test.exs
@@ -68,7 +68,8 @@ defmodule CodexPooler.Upstreams.Reconciliation.CreditBalanceReconciliationTest d
         used_percent: Decimal.new(30),
         source: "codex_rate_limit_event",
         source_precision: "observed",
-        reset_at: DateTime.add(now, 86_400),
+        # Keep this distinct from the usage reset beyond presentation tolerance.
+        reset_at: DateTime.add(now, 93_600),
         observed_at: DateTime.utc_now(),
         freshness_state: "fresh"
       })

--- a/test/codex_pooler_web/live/admin/pages/upstreams_live_test.exs
+++ b/test/codex_pooler_web/live/admin/pages/upstreams_live_test.exs
@@ -8807,7 +8807,7 @@ defmodule CodexPoolerWeb.Admin.UpstreamsLiveTest do
     [assignment] = account.assignments
     assert assignment.quota_priming_status == Keyword.fetch!(opts, :priming_status)
     assert assignment.quota_priming_label == Keyword.fetch!(opts, :priming_label)
-    assert Enum.map(account.quota_limits, & &1.label) == ["5h", "30d", "Weekly"]
+    assert Enum.map(account.quota_limits, & &1.label) == ["5h", "30d", "Account Weekly"]
   end
 
   defp runtime_secret(label),

--- a/test/codex_pooler_web/live/admin/read_models/upstream_accounts_read_model/quota_observations_test.exs
+++ b/test/codex_pooler_web/live/admin/read_models/upstream_accounts_read_model/quota_observations_test.exs
@@ -92,6 +92,62 @@ defmodule CodexPoolerWeb.Admin.UpstreamAccountsReadModel.QuotaObservationsTest d
     assert length(row.observations) == 2
   end
 
+  test "ordinary chronological usage growth preserves the selected meter" do
+    older =
+      window(
+        source: "codex_response_headers",
+        used_percent: Decimal.new(5),
+        observed_at: DateTime.add(@now, -300)
+      )
+
+    for raw <- [[older, window()], [window(), older]] do
+      row = weekly(raw)
+      refute row.source_disagreement
+      assert row.percent_label == row.selected_percent_label
+      assert row.percent_label == "94%"
+      assert length(row.observations) == 2
+    end
+  end
+
+  test "chronological usage decrease stays uncertain while both windows remain open" do
+    older =
+      window(
+        source: "codex_response_headers",
+        used_percent: Decimal.new(6),
+        observed_at: DateTime.add(@now, -300)
+      )
+
+    newer = window(used_percent: Decimal.new(5))
+
+    for raw <- [[older, newer], [newer, older]] do
+      row = weekly(raw)
+      assert row.source_disagreement
+      assert row.percent_label == "sources differ"
+      refute row.reset_disagreement
+    end
+  end
+
+  test "reset presentation tolerates up to one minute of timestamp drift" do
+    for seconds <- [1, 60] do
+      header =
+        window(source: "codex_response_headers", reset_at: DateTime.add(@new_reset, seconds))
+
+      row = weekly([window(), header])
+      refute row.reset_disagreement
+      refute row.source_disagreement
+      assert row.reset_at != nil
+      assert length(row.observations) == 2
+    end
+
+    header = window(source: "codex_response_headers", reset_at: DateTime.add(@new_reset, 61))
+    assert weekly([window(), header]).reset_disagreement
+
+    missing = window(source: "codex_response_headers", reset_at: nil)
+    row = weekly([window(), missing])
+    refute row.reset_disagreement
+    assert Enum.any?(row.observations, &(&1.reset_at == "not reported"))
+  end
+
   test "missing, unknown, zero and exhausted remain distinct" do
     assert weekly([]).percent_label == "not reported"
     assert weekly([window(used_percent: nil)]).percent_label == "not reported"
@@ -119,8 +175,9 @@ defmodule CodexPoolerWeb.Admin.UpstreamAccountsReadModel.QuotaObservationsTest d
     assert hd(row.observations).reset_at == "not reported"
   end
 
-  test "fresh versus exhausted and all stale disagreements retain evidence states" do
+  test "equal observation times with different usage stay uncertain, including all stale reports" do
     header = window(source: "codex_response_headers", used_percent: Decimal.new(100))
+    assert header.observed_at == window().observed_at
     assert weekly([window(), header]).source_disagreement
     old = DateTime.add(@now, -901)
     row = weekly([window(observed_at: old), %{header | observed_at: old}])

--- a/test/codex_pooler_web/live/admin/read_models/upstream_accounts_read_model/quota_observations_test.exs
+++ b/test/codex_pooler_web/live/admin/read_models/upstream_accounts_read_model/quota_observations_test.exs
@@ -111,7 +111,10 @@ defmodule CodexPoolerWeb.Admin.UpstreamAccountsReadModel.QuotaObservationsTest d
 
   test "reset disagreement alone remains visible and missing reset is explicit" do
     header = window(source: "codex_response_headers", reset_at: @old_reset)
-    assert weekly([window(), header]).source_disagreement
+    reset_only = weekly([window(), header])
+    assert reset_only.reset_disagreement
+    refute reset_only.source_disagreement
+    assert reset_only.percent_label == "94%"
     row = weekly([window(reset_at: nil)])
     assert hd(row.observations).reset_at == "not reported"
   end
@@ -129,7 +132,7 @@ defmodule CodexPoolerWeb.Admin.UpstreamAccountsReadModel.QuotaObservationsTest d
     legacy =
       window(source: "codex_response_headers", window_kind: "primary", reset_at: @old_reset)
 
-    assert weekly([window(), legacy]).source_disagreement
+    assert weekly([window(), legacy]).reset_disagreement
   end
 
   test "usage parser retains normal_model_slug as metadata and separate additional scopes" do

--- a/test/codex_pooler_web/live/admin/read_models/upstream_accounts_read_model/quota_observations_test.exs
+++ b/test/codex_pooler_web/live/admin/read_models/upstream_accounts_read_model/quota_observations_test.exs
@@ -1,0 +1,224 @@
+defmodule CodexPoolerWeb.Admin.UpstreamAccountsReadModel.QuotaObservationsTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.LiveViewTest, only: [render_component: 2]
+
+  alias CodexPooler.Quotas.Evidence
+  alias CodexPooler.Upstreams.Quota.AccountQuotaWindow
+  alias CodexPooler.Upstreams.Quota.WindowSelector
+  alias CodexPoolerWeb.Admin.UpstreamAccountsReadModel.QuotaProjection
+  alias CodexPoolerWeb.Admin.UpstreamPageComponents.AccountCard.QuotaLimitRow
+  alias CodexPoolerWeb.DateTimeDisplay
+
+  @now ~U[2026-09-07 01:12:35Z]
+  @old_reset ~U[2026-09-13 20:49:16Z]
+  @new_reset ~U[2026-09-14 00:57:27Z]
+
+  test "future reset disagreement survives stale-header deduplication without changing routing" do
+    old =
+      window(
+        source: "codex_response_headers",
+        used_percent: Decimal.new(98),
+        observed_at: ~U[2026-09-07 00:51:13Z],
+        reset_at: @old_reset
+      )
+
+    fresh = window()
+
+    for raw <- [[old, fresh], [fresh, old]] do
+      assert [^fresh] = WindowSelector.logical_windows(raw, @now)
+      row = weekly(raw)
+      assert row.label == "Account Weekly"
+      assert row.percent == nil
+      assert row.percent_label == "sources differ"
+      assert row.selected_percent_label == "94%"
+      assert row.selected_source == "codex_usage_api"
+      assert row.reset_display_state == :absent
+      assert [header, usage] = row.observations
+      assert header.used == "98%"
+      assert header.remaining == "2%"
+      assert header.freshness == "stale"
+      assert header.observed_at == "2026-09-07T00:51:13Z"
+      assert header.reset_at == "2026-09-13T20:49:16Z"
+      refute header.elapsed
+      assert usage.used == "6%"
+      assert usage.remaining == "94%"
+      assert usage.freshness == "fresh"
+      assert [^fresh] = WindowSelector.logical_windows(raw, @now)
+
+      html = render_component(&QuotaLimitRow.quota_limit_row/1, id: "test-weekly", limit: row)
+      assert html =~ "Sources disagree; remaining quota is uncertain"
+      assert html =~ "codex_response_headers"
+      assert html =~ "98% used / 2% remaining"
+      assert html =~ "2026-09-13T20:49:16Z"
+      assert html =~ "data-freshness=\"stale\""
+      assert html =~ "<details open"
+    end
+  end
+
+  test "actual elapsed reset does not conflict with a fresh new window" do
+    ended =
+      window(
+        source: "codex_response_headers",
+        used_percent: Decimal.new(100),
+        observed_at: DateTime.add(@now, -3600),
+        reset_at: DateTime.add(@now, -1)
+      )
+
+    row = weekly([ended, window()])
+    refute row.source_disagreement
+    assert row.percent_label == "94%"
+    assert Enum.any?(row.observations, & &1.elapsed)
+  end
+
+  test "future observations cannot influence a historical view" do
+    future =
+      window(
+        source: "codex_response_headers",
+        used_percent: Decimal.new(99),
+        observed_at: DateTime.add(@now, 1)
+      )
+
+    row = weekly([window(), future])
+    refute row.source_disagreement
+    assert length(row.observations) == 1
+  end
+
+  test "ordinary agreeing sources and equivalent decimals keep a normal meter" do
+    header = window(source: "codex_response_headers", used_percent: Decimal.new("6.0"))
+    row = weekly([window(), header])
+    refute row.source_disagreement
+    assert row.percent_label == "94%"
+    assert length(row.observations) == 2
+  end
+
+  test "missing, unknown, zero and exhausted remain distinct" do
+    assert weekly([]).percent_label == "not reported"
+    assert weekly([window(used_percent: nil)]).percent_label == "not reported"
+    zero = weekly([window(used_percent: Decimal.new(0))])
+    assert zero.percent_label == "100%"
+    assert hd(zero.observations).used == "0%"
+    exhausted = weekly([window(used_percent: Decimal.new(100))])
+    assert exhausted.percent_label == "0%"
+
+    stale =
+      weekly([window(used_percent: Decimal.new(100), observed_at: DateTime.add(@now, -901))])
+
+    assert stale.meter_state == :historical_exhausted
+    assert hd(stale.observations).freshness == "stale"
+    refute stale.source_disagreement
+  end
+
+  test "reset disagreement alone remains visible and missing reset is explicit" do
+    header = window(source: "codex_response_headers", reset_at: @old_reset)
+    assert weekly([window(), header]).source_disagreement
+    row = weekly([window(reset_at: nil)])
+    assert hd(row.observations).reset_at == "not reported"
+  end
+
+  test "fresh versus exhausted and all stale disagreements retain evidence states" do
+    header = window(source: "codex_response_headers", used_percent: Decimal.new(100))
+    assert weekly([window(), header]).source_disagreement
+    old = DateTime.add(@now, -901)
+    row = weekly([window(observed_at: old), %{header | observed_at: old}])
+    assert row.source_disagreement
+    assert Enum.all?(row.observations, &(&1.freshness == "stale"))
+  end
+
+  test "legacy weekly primary reports still share one account evidence group" do
+    legacy =
+      window(source: "codex_response_headers", window_kind: "primary", reset_at: @old_reset)
+
+    assert weekly([window(), legacy]).source_disagreement
+  end
+
+  test "usage parser retains normal_model_slug as metadata and separate additional scopes" do
+    payload = %{
+      "rate_limit" => %{"primary_window" => usage_window(6)},
+      "additional_rate_limits" => [
+        %{
+          "limit_name" => "GPT-Reserve",
+          "metered_feature" => "base_model_inference",
+          "normal_model_slug" => "gpt-5.6-luna",
+          "rate_limit" => %{"primary_window" => usage_window(0)}
+        },
+        %{
+          "limit_name" => "GPT-5.3-Codex-Spark",
+          "metered_feature" => "codex_spark",
+          "rate_limit" => %{"primary_window" => usage_window(0)}
+        }
+      ]
+    }
+
+    {:ok, result} = Evidence.CodexParsers.parse_codex_usage_result(payload, @now)
+    reserve = Enum.find(result.windows, &(&1.raw_metered_feature == "base_model_inference"))
+    assert reserve.metadata["normal_model_slug"] == "gpt-5.6-luna"
+
+    {:ok, original} =
+      Evidence.CodexParsers.parse_codex_usage_result(
+        update_in(
+          payload["additional_rate_limits"],
+          &Enum.map(&1, fn limit -> Map.delete(limit, "normal_model_slug") end)
+        ),
+        @now
+      )
+
+    assert Enum.map(result.windows, &Evidence.logical_window_key/1) ==
+             Enum.map(original.windows, &Evidence.logical_window_key/1)
+
+    raw = Enum.map(result.windows, &struct(AccountQuotaWindow, Map.from_struct(&1)))
+    rows = project(raw)
+    assert Enum.find(rows, &(&1.key == :weekly)).label == "Account Weekly"
+    reserve_row = Enum.find(rows, &String.contains?(&1.label, "Reserve"))
+    assert reserve_row.percent_label == "100%"
+    assert hd(reserve_row.observations).descriptor =~ "gpt-5.6-luna"
+    spark_row = Enum.find(rows, &String.contains?(&1.label, "Spark"))
+    assert spark_row.percent_label == "100%"
+    refute spark_row.source_disagreement
+  end
+
+  defp usage_window(used),
+    do: %{
+      "used_percent" => used,
+      "limit_window_seconds" => 604_800,
+      "reset_after_seconds" => DateTime.diff(@new_reset, @now),
+      "reset_at" => DateTime.to_unix(@new_reset)
+    }
+
+  defp weekly(raw), do: Enum.find(project(raw), &(&1.key == :weekly))
+
+  defp project(raw) do
+    QuotaProjection.quota_limit_rows(
+      WindowSelector.logical_windows(raw, @now),
+      DateTimeDisplay.preferences_for_user(nil),
+      @now,
+      nil,
+      raw
+    )
+  end
+
+  defp window(attrs \\ []) do
+    struct!(
+      AccountQuotaWindow,
+      Keyword.merge(
+        [
+          quota_key: "account",
+          quota_scope: "account",
+          quota_family: "account",
+          window_kind: "secondary",
+          window_minutes: 10_080,
+          source: "codex_usage_api",
+          source_precision: "observed",
+          freshness_state: "fresh",
+          observed_at: ~U[2026-09-07 01:12:00Z],
+          last_sync_at: ~U[2026-09-07 01:12:00Z],
+          reset_at: @new_reset,
+          used_percent: Decimal.new(6),
+          merge_precedence: 60,
+          metadata: %{}
+        ],
+        attrs
+      )
+    )
+  end
+end


### PR DESCRIPTION
Quota reports can disagree while both reset timestamps are still in the future. The admin meter currently receives only the routing selector's effective row and can silently show one confident remaining percentage when a stale header reports much higher usage than a fresh API observation.

Project time-visible raw observations beside the selected row. A decrease in usage across ordered sources before either reported window ends shows `sources differ`; ordinary chronological growth keeps the selected meter. Different values at equal or unknown observation times also remain uncertain. Details retain every available source's used/remaining percentage, observed time, reset and current freshness, including stale evidence. A reset difference greater than 60 seconds replaces the countdown with a separate warning; the UI tolerance does not identify quota cycles or alter timestamps. Missing resets remain explicit. Elapsed windows remain inspectable without causing a current-window conflict.

Preserve `normal_model_slug` in additional-meter metadata and show Account Weekly separately from Spark/Reserve/model quotas. Parent list and cockpit filters retain rows with uncertain percentages/resets. Raw additional-meter identity tokens remain hashed in the projection.

Routing selection, the existing freshness TTL, availability and database schema are unchanged; the routing selector's code AST matches the pinned upstream 0.7.1 base. A later future reset is no longer described as proof of a new cycle. The provider discrepancy itself remains unresolved, and the patch does not reconstruct observations already overwritten by their own source.

Validation: the final source passed `mix format --check-formatted`, warnings-as-errors compilation, `mix quality.xref`, strict Credo, asset builds and the complete default upstream test suite (`make test-fast N=4`, four passing partitions), both locally and in the [GitHub Actions verification job](https://github.com/korkin25/codex-pooler/actions/runs/34074333951). The 13 focused/integration checks cover chronological growth/regression, equal timestamps, reset tolerance boundaries, expired windows, missing/zero/exhausted/stale data, descriptors and both LiveView views. The routing selector AST matches upstream; configuration, locked dependencies and database migrations are unchanged. All quota fixtures and database activity are synthetic.
