### PR TITLE
fix: bound Prometheus histogram memory between scrapes

### DIFF
--- a/lib/codex_pooler_web/controllers/operations/metrics_controller.ex
+++ b/lib/codex_pooler_web/controllers/operations/metrics_controller.ex
@@ -2,13 +2,14 @@ defmodule CodexPoolerWeb.Operations.MetricsController do
   use CodexPoolerWeb, :controller
 
   alias CodexPooler.InstanceSettings
+  alias CodexPoolerWeb.Telemetry.PrometheusReporter
 
   def show(conn, _params) do
     case authorize_metrics(conn) do
       :ok ->
         conn
         |> put_resp_content_type("text/plain; version=0.0.4")
-        |> send_resp(200, TelemetryMetricsPrometheus.Core.scrape())
+        |> send_resp(200, PrometheusReporter.scrape())
 
       {:error, reason} ->
         conn

--- a/lib/codex_pooler_web/telemetry.ex
+++ b/lib/codex_pooler_web/telemetry.ex
@@ -179,8 +179,7 @@ defmodule CodexPoolerWeb.Telemetry do
 
   @spec prometheus_metrics() :: [metric()]
   def prometheus_metrics do
-    # Prometheus Core 1.2.1 enumerates metric.tags and invokes metric.tag_values.
-    # Keep this split until the reporter supports Telemetry.Metrics 1.2 function-valued tags.
+    # Both scalar and histogram handlers consume explicit tags/tag_values.
     [
       counter("phoenix.endpoint.stop.count",
         event_name: [:phoenix, :endpoint, :stop],
@@ -559,7 +558,7 @@ defmodule CodexPoolerWeb.Telemetry do
   @spec prometheus_reporter_child() :: {module(), keyword()} | nil
   defp prometheus_reporter_child do
     if prometheus_reporter_enabled?() do
-      {TelemetryMetricsPrometheus.Core, metrics: prometheus_metrics()}
+      {__MODULE__.PrometheusReporter, metrics: prometheus_metrics()}
     end
   end
 

--- a/lib/codex_pooler_web/telemetry/histogram_collector.ex
+++ b/lib/codex_pooler_web/telemetry/histogram_collector.ex
@@ -1,0 +1,122 @@
+defmodule CodexPoolerWeb.Telemetry.HistogramCollector do
+  @moduledoc false
+  use GenServer
+
+  alias TelemetryMetricsPrometheus.Core
+
+  def start_link(opts), do: GenServer.start_link(__MODULE__, opts)
+
+  def metrics(name), do: :persistent_term.get({__MODULE__, name})
+
+  @impl true
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+    name = Keyword.fetch!(opts, :name)
+    metrics = Keyword.fetch!(opts, :metrics)
+    %{aggregates_table_id: table} = Core.Registry.config(name)
+    table = :ets.whereis(table)
+
+    # Validate everything before attaching the first handler.
+    Enum.each(metrics, &Core.Registry.validate_distribution_buckets!/1)
+
+    handlers =
+      Enum.map(metrics, fn metric ->
+        id = {__MODULE__, name, metric.name}
+        # A killed process cannot run terminate/2; replace its stale handler.
+        :telemetry.detach(id)
+        boundaries = Core.Registry.validate_distribution_buckets!(metric)
+        config = %{metric: metric, table: table, buckets: boundaries}
+        :ok = :telemetry.attach(id, metric.event_name, &__MODULE__.handle_event/4, config)
+        id
+      end)
+
+    :persistent_term.put({__MODULE__, name}, metrics)
+    {:ok, %{name: name, handlers: handlers}}
+  end
+
+  @impl true
+  def terminate(_reason, state) do
+    Enum.each(state.handlers, &:telemetry.detach/1)
+    :persistent_term.erase({__MODULE__, state.name})
+    :ok
+  end
+
+  @doc false
+  def handle_event(_event, measurements, metadata, config) do
+    case observation(config.metric, measurements, metadata) do
+      {:ok, key, value} ->
+        head_key = if match_variable?(key), do: :"$2", else: key
+        update(config.table, key, head_key, value, config.buckets)
+
+      :skip ->
+        :ok
+    end
+  end
+
+  defp observation(metric, measurements, metadata) do
+    with true <- Core.EventHandler.keep?(metric.keep, metadata),
+         {:ok, value} <-
+           Core.EventHandler.get_measurement(measurements, metadata, metric.measurement),
+         tags when is_map(tags) <- metric.tag_values.(metadata),
+         :ok <- Core.EventHandler.validate_tags_in_tag_values(metric.tags, tags) do
+      {:ok, {metric.name, Map.take(tags, metric.tags)}, value}
+    else
+      _missing_or_invalid -> :skip
+    end
+  rescue
+    # Unit conversion can raise before Core validates malformed input. Only
+    # callback extraction is guarded; aggregation bugs must remain visible.
+    _error in [ArithmeticError, ArgumentError, BadMapError, KeyError] -> :skip
+  end
+
+  # Normal string labels retain ETS's bound-key fast path. Unusual literal
+  # match-variable atoms must be compared through a constant guard instead.
+  defp match_variable?(value) when is_atom(value) do
+    value == :_ or String.starts_with?(Atom.to_string(value), "$")
+  end
+
+  defp match_variable?(value) when is_list(value), do: Enum.any?(value, &match_variable?/1)
+
+  defp match_variable?(value) when is_tuple(value),
+    do: value |> Tuple.to_list() |> match_variable?()
+
+  defp match_variable?(value) when is_map(value), do: value |> Map.to_list() |> match_variable?()
+  defp match_variable?(_value), do: false
+
+  defp update(table, key, head_key, value, boundaries) do
+    case :ets.lookup(table, key) do
+      [] ->
+        buckets = Enum.map(boundaries, &{to_string(&1), if(value <= &1, do: 1, else: 0)})
+        initial = {buckets ++ [{"+Inf", 1}], 1, value}
+
+        if :ets.insert_new(table, {key, initial}),
+          do: :ok,
+          else: update(table, key, head_key, value, boundaries)
+
+      [{^key, {buckets, count, sum} = previous}] ->
+        updated = {increment_buckets(buckets, boundaries, value), count + 1, sum + value}
+
+        match_spec = [
+          {{head_key, :"$1"},
+           [{:"=:=", {:element, 1, :"$_"}, {:const, key}}, {:"=:=", :"$1", {:const, previous}}],
+           [{{{:element, 1, :"$_"}, {:const, updated}}}]}
+        ]
+
+        case :ets.select_replace(table, match_spec) do
+          1 -> :ok
+          0 -> update(table, key, head_key, value, boundaries)
+        end
+    end
+  rescue
+    error in ArgumentError ->
+      # An event already executing during registry shutdown can outlive detach.
+      # Its old table id must never write into the replacement registry.
+      if :ets.info(table) == :undefined, do: :ok, else: reraise(error, __STACKTRACE__)
+  end
+
+  defp increment_buckets(buckets, boundaries, value) do
+    Enum.zip_with(boundaries ++ [:infinity], buckets, fn boundary, {label, count} ->
+      {label, count + if(boundary == :infinity or value <= boundary, do: 1, else: 0)}
+    end)
+  end
+end

--- a/lib/codex_pooler_web/telemetry/prometheus_reporter.ex
+++ b/lib/codex_pooler_web/telemetry/prometheus_reporter.ex
@@ -1,0 +1,45 @@
+defmodule CodexPoolerWeb.Telemetry.PrometheusReporter do
+  @moduledoc """
+  Core's exporter and scalar metrics with immediately aggregated histograms.
+
+  Core 1.2.1 retains raw distribution samples until a scrape. Keep those
+  handlers out of the registry so memory depends on series and bucket count,
+  rather than the number of observations between scrapes.
+  """
+  use Supervisor
+
+  alias CodexPoolerWeb.Telemetry.HistogramCollector
+  alias Telemetry.Metrics.Distribution
+  alias TelemetryMetricsPrometheus.Core
+
+  def child_spec(opts) do
+    %{id: Keyword.get(opts, :name, :prometheus_metrics), start: {__MODULE__, :start_link, [opts]}}
+  end
+
+  def start_link(opts), do: Supervisor.start_link(__MODULE__, opts)
+
+  @impl true
+  def init(opts) do
+    name = Keyword.get(opts, :name, :prometheus_metrics)
+    metrics = Keyword.fetch!(opts, :metrics)
+    {histograms, scalars} = Enum.split_with(metrics, &match?(%Distribution{}, &1))
+
+    children = [
+      {Core, name: name, metrics: scalars, start_async: false},
+      {HistogramCollector, name: name, metrics: histograms}
+    ]
+
+    # Core owns ETS. Restart both children together so attached handlers never
+    # retain a table from a previous registry generation.
+    Supervisor.init(children, strategy: :one_for_all)
+  end
+
+  def scrape(name \\ :prometheus_metrics) do
+    %{aggregates_table_id: table} = Core.Registry.config(name)
+    metrics = Core.Registry.metrics(name) ++ HistogramCollector.metrics(name)
+
+    table
+    |> Core.Aggregator.get_time_series()
+    |> Core.Exporter.export(metrics)
+  end
+end

--- a/test/codex_pooler_web/histogram_collector_test.exs
+++ b/test/codex_pooler_web/histogram_collector_test.exs
@@ -1,0 +1,212 @@
+defmodule CodexPoolerWeb.HistogramCollectorTest do
+  use ExUnit.Case, async: false
+
+  alias CodexPoolerWeb.Telemetry.HistogramCollector
+  alias CodexPoolerWeb.Telemetry.PrometheusReporter
+  alias TelemetryMetricsPrometheus.Core
+
+  @reporter :bounded_histogram_test
+  @event [:bounded_histogram_test, :sample]
+  @metric [:bounded_histogram_test, :duration, :seconds]
+  @tags %{source: "fixture"}
+  @key {@metric, @tags}
+
+  setup do
+    metric =
+      Telemetry.Metrics.distribution(@metric,
+        event_name: @event,
+        measurement: :duration,
+        tags: [:source],
+        tag_values: &Map.take(&1, [:source]),
+        keep: &(!Map.get(&1, :skip, false)),
+        unit: {:millisecond, :second},
+        reporter_options: [buckets: [0, 0.125, 0.25, 1]]
+      )
+
+    supervisor = start_supervised!({PrometheusReporter, name: @reporter, metrics: [metric]})
+    %{aggregates_table_id: table, dist_table_id: raw} = Core.Registry.config(@reporter)
+    %{table: table, raw: raw, supervisor: supervisor, metric: metric}
+  end
+
+  test "a million observations without scraping retain one fixed-size aggregate", context do
+    emit(125)
+    warm_memory = :ets.info(context.table, :memory)
+
+    for _ <- 1..99_999, do: emit(125)
+
+    assert aggregate(context.table) ==
+             {[
+                {"0", 0},
+                {"0.125", 100_000},
+                {"0.25", 100_000},
+                {"1", 100_000},
+                {"+Inf", 100_000}
+              ], 100_000, 12_500.0}
+
+    memory_100k = :ets.info(context.table, :memory)
+
+    1..8
+    |> Task.async_stream(fn _ -> for _ <- 1..112_500, do: emit(125) end,
+      max_concurrency: 8,
+      timeout: 120_000,
+      ordered: false
+    )
+    |> Enum.each(fn result -> assert match?({:ok, _}, result) end)
+
+    {buckets, count, sum} = aggregate(context.table)
+    assert count == 1_000_000
+    assert sum == 125_000.0
+    assert List.last(buckets) == {"+Inf", count}
+    assert :ets.info(context.table, :size) == 1
+    assert :ets.info(context.raw, :size) == 0
+    assert memory_100k <= warm_memory + 1024
+    assert :ets.info(context.table, :memory) <= memory_100k + 1024
+
+    IO.puts(
+      "histogram no-scrape 100k/1m: one aggregate, zero raw samples, memory words #{memory_100k}/#{:ets.info(context.table, :memory)}"
+    )
+  end
+
+  test "exact inclusive boundaries, fractional sums and repeated scrapes preserve exposition",
+       context do
+    for value <- [0, 125, 250, 1000, 1250], do: emit(value)
+
+    assert aggregate(context.table) == {
+             [{"0", 1}, {"0.125", 2}, {"0.25", 3}, {"1", 4}, {"+Inf", 5}],
+             5,
+             2.625
+           }
+
+    first = PrometheusReporter.scrape(@reporter)
+    assert first == PrometheusReporter.scrape(@reporter)
+
+    assert first =~
+             ~s(bounded_histogram_test_duration_seconds_bucket{source="fixture",le="0.125"} 2)
+
+    assert first =~ ~s(bounded_histogram_test_duration_seconds_sum{source="fixture"} 2.625)
+    assert first =~ ~s(bounded_histogram_test_duration_seconds_count{source="fixture"} 5)
+    assert :ets.info(context.raw, :size) == 0
+  end
+
+  test "concurrent first writes and scrapes cannot lose increments", context do
+    writers = for _ <- 1..8, do: Task.async(fn -> for _ <- 1..1000, do: emit(125) end)
+    for _ <- 1..50, do: assert(PrometheusReporter.scrape(@reporter) |> is_binary())
+    Enum.each(writers, &Task.await(&1, 30_000))
+    {buckets, count, sum} = aggregate(context.table)
+    assert count == 8000
+    assert sum == 1000.0
+    assert List.last(buckets) == {"+Inf", 8000}
+  end
+
+  test "keep, transformed tags, malformed measurements and missing labels are respected",
+       context do
+    :telemetry.execute(@event, %{duration: 125}, %{source: "fixture", skip: true})
+    :telemetry.execute(@event, %{}, @tags)
+    :telemetry.execute(@event, %{duration: nil}, @tags)
+    :telemetry.execute(@event, %{duration: "bad"}, @tags)
+    :telemetry.execute(@event, %{duration: 125}, %{})
+    assert :ets.info(context.table, :size) == 0
+    emit(125)
+    assert {_, 1, 0.125} = aggregate(context.table)
+  end
+
+  test "registry restart replaces table and handlers before collecting again", context do
+    emit(125)
+    old_table = :ets.whereis(context.table)
+    old_registry = Process.whereis(@reporter)
+    Process.exit(old_registry, :kill)
+
+    eventually(fn ->
+      current = Process.whereis(@reporter)
+
+      current != nil and current != old_registry and :ets.whereis(context.table) != old_table and
+        length(:telemetry.list_handlers(@event)) == 1
+    end)
+
+    assert :ets.info(old_table) == :undefined
+    # Wait for the collector child to finish synchronous registration too.
+    eventually(fn ->
+      Enum.any?(Supervisor.which_children(context.supervisor), fn
+        {HistogramCollector, pid, _, _} -> is_pid(pid)
+        _ -> false
+      end)
+    end)
+
+    emit(250)
+    assert {_, 1, 0.25} = aggregate(context.table)
+    assert :ets.info(context.raw, :size) == 0
+    assert length(:telemetry.list_handlers(@event)) == 1
+  end
+
+  test "collector kill replaces its handler without leaving duplicates", context do
+    emit(125)
+
+    {HistogramCollector, old, _, _} =
+      Enum.find(
+        Supervisor.which_children(context.supervisor),
+        &(elem(&1, 0) == HistogramCollector)
+      )
+
+    old_table = :ets.whereis(context.table)
+    Process.exit(old, :kill)
+
+    eventually(fn ->
+      Enum.any?(Supervisor.which_children(context.supervisor), fn
+        {HistogramCollector, pid, _, _} -> is_pid(pid) and pid != old
+        _ -> false
+      end)
+    end)
+
+    assert :ets.whereis(context.table) != old_table
+    assert length(:telemetry.list_handlers(@event)) == 1
+    emit(125)
+    assert {_, 1, 0.125} = aggregate(context.table)
+  end
+
+  test "literal match-variable labels do not corrupt or stall other series", context do
+    emit(125)
+
+    for label <- [:"$1", :_, :"$_"] do
+      for _ <- 1..2, do: :telemetry.execute(@event, %{duration: 250}, %{source: label})
+
+      assert [{{@metric, %{source: ^label}}, {_, 2, 0.5}}] =
+               :ets.lookup(context.table, {@metric, %{source: label}})
+    end
+
+    assert {_, 1, 0.125} = aggregate(context.table)
+  end
+
+  test "updates remain efficient with 500 existing series", context do
+    for id <- 1..500 do
+      :telemetry.execute(@event, %{duration: 125}, %{source: "fixture-#{id}"})
+    end
+
+    {elapsed, _} = :timer.tc(fn -> for _ <- 1..10_000, do: emit(125) end)
+    assert :ets.info(context.table, :size) == 501
+    assert {_, 10_000, 1250.0} = aggregate(context.table)
+    assert elapsed < 10_000_000
+    IO.puts("histogram 500-series 10k updates: #{elapsed}us")
+  end
+
+  test "stopping reporter detaches handlers", context do
+    assert length(:telemetry.list_handlers(@event)) == 1
+    Supervisor.stop(context.supervisor)
+    assert :telemetry.list_handlers(@event) == []
+  end
+
+  defp emit(milliseconds), do: :telemetry.execute(@event, %{duration: milliseconds}, @tags)
+  defp aggregate(table), do: table |> :ets.lookup(@key) |> hd() |> elem(1)
+
+  defp eventually(check, remaining \\ 200)
+  defp eventually(check, 0), do: assert(check.())
+
+  defp eventually(check, remaining) do
+    if check.(),
+      do: :ok,
+      else:
+        (
+          Process.sleep(10)
+          eventually(check, remaining - 1)
+        )
+  end
+end


### PR DESCRIPTION
Prometheus Core 1.2.1 stores each distribution observation until the next scrape.
With telemetry enabled and no scraper, routine database queries keep growing the
raw-sample ETS table: a synthetic run increased its memory from 181,384 bytes at
1,000 events to 16,015,816 bytes at 100,000 events.

Aggregate histograms when observations arrive, retaining one bucket/count/sum row
per metric and label combination. Keep Core's scalar handlers and exporter, the
existing inclusive bucket boundaries and fractional sums, and the metrics
endpoint's authorization and response format. Memory depends on distinct series
and configured buckets rather than observations between scrapes.

Validation of the identical collector/reporter/test implementation: nine regression
tests passed, including one million events without scraping, concurrent writers
and scrapes, exact boundaries and sums, malformed measurements, and collector
restart/detachment. The no-scrape test retained one aggregate and zero raw samples,
using 1,449 ETS words at both 100,000 and 1,000,000 events. Compilation, strict Credo
and compile-connected xref checks passed for that implementation. No dependencies
are added or upgraded.
