### PR TITLE
fix: keep HTTP session owner leases alive and fence stale completions

### DIFF
--- a/lib/codex_pooler/gateway/persistence/session_continuity.ex
+++ b/lib/codex_pooler/gateway/persistence/session_continuity.ex
@@ -186,14 +186,22 @@ defmodule CodexPooler.Gateway.Persistence.SessionContinuity do
     now = now()
 
     Repo.transaction(fn ->
-      session = codex_session_for_update!(session.id)
+      # The caller carries the admitted token. Reloading the session first would
+      # let an old response mutate a replacement owner's continuity and account.
+      codex_session_for_update!(session.id)
+
+      session =
+        case OwnerLease.renew_owner_token(session, session.owner_lease_token, opts) do
+          {:ok, renewed_session} -> renewed_session
+          {:error, reason} -> Repo.rollback(reason)
+        end
+
       auth = %{pool: %{id: session.pool_id}, api_key: %{id: session.api_key_id}}
       session = maybe_bind_session_assignment!(session, opts, now)
 
       continuity_opts = Aliases.continuity_opts(opts, payload, response_body)
 
       Aliases.register!(session, auth, continuity_opts, now)
-      OwnerLease.renew!(session, opts, now)
       :ok
     end)
     |> unwrap_ok_transaction()

--- a/lib/codex_pooler/gateway/persistence/session_continuity/owner_lease.ex
+++ b/lib/codex_pooler/gateway/persistence/session_continuity/owner_lease.ex
@@ -84,21 +84,6 @@ defmodule CodexPooler.Gateway.Persistence.SessionContinuity.OwnerLease do
     |> Repo.update!()
   end
 
-  @spec renew!(CodexSession.t(), RequestOptions.t(), DateTime.t()) :: BridgeOwnerLease.t() | :ok
-  def renew!(%CodexSession{} = session, %RequestOptions{} = opts, now) do
-    case active_for_update(session.id) do
-      %BridgeOwnerLease{} = lease ->
-        expires_at = DateTime.add(now, bridge_owner_lease_ttl_seconds(opts), :second)
-
-        lease
-        |> Ecto.Changeset.change(%{renewed_at: now, expires_at: expires_at, updated_at: now})
-        |> Repo.update!()
-
-      nil ->
-        :ok
-    end
-  end
-
   @spec validate(session_ref(), Ecto.UUID.t() | String.t()) :: owner_token_result()
   def validate(session_ref, owner_lease_token) do
     now = now()
@@ -112,14 +97,29 @@ defmodule CodexPooler.Gateway.Persistence.SessionContinuity.OwnerLease do
     end
   end
 
+  # The caller must hold a transaction for these locks to fence later writes.
+  @doc false
+  @spec validate_for_update(session_ref(), Ecto.UUID.t() | String.t()) :: owner_token_result()
+  def validate_for_update(session_ref, owner_lease_token) do
+    unless Repo.in_transaction?(),
+      do: raise(ArgumentError, "owner validation requires a transaction")
+
+    case active_snapshot_for_update(session_ref) do
+      {:ok, session, lease} ->
+        validate_owner_token_snapshot(session, lease, owner_lease_token, now())
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
   @spec renew_owner_token(session_ref(), Ecto.UUID.t() | String.t(), RequestOptions.t()) ::
           {:ok, CodexSession.t()} | {:error, :stale_owner | :owner_unavailable}
   def renew_owner_token(session_ref, owner_lease_token, %RequestOptions{} = opts) do
-    now = now()
-
     Repo.transaction(fn ->
       with {:ok, %CodexSession{} = session, %BridgeOwnerLease{} = lease} <-
              active_snapshot_for_update(session_ref),
+           now = now(),
            :ok <- validate_owner_token_snapshot(session, lease, owner_lease_token, now) do
         expires_at = DateTime.add(now, bridge_owner_lease_ttl_seconds(opts), :second)
 
@@ -128,15 +128,7 @@ defmodule CodexPooler.Gateway.Persistence.SessionContinuity.OwnerLease do
           |> Ecto.Changeset.change(%{renewed_at: now, expires_at: expires_at, updated_at: now})
           |> Repo.update!()
 
-        session
-        |> Ecto.Changeset.change(%{
-          owner_instance_id: renewed_lease.owner_instance_id,
-          owner_lease_token: renewed_lease.lease_token,
-          owner_lease_expires_at: renewed_lease.expires_at,
-          last_heartbeat_at: now,
-          updated_at: now
-        })
-        |> Repo.update!()
+        persist_session!(session, renewed_lease, now)
       else
         {:error, reason} -> Repo.rollback(reason)
       end

--- a/lib/codex_pooler/gateway/persistence/session_continuity/turn_lifecycle.ex
+++ b/lib/codex_pooler/gateway/persistence/session_continuity/turn_lifecycle.ex
@@ -12,6 +12,7 @@ defmodule CodexPooler.Gateway.Persistence.SessionContinuity.TurnLifecycle do
     CodexTurn
   }
 
+  alias CodexPooler.Gateway.Persistence.SessionContinuity.OwnerLease
   alias CodexPooler.Gateway.Persistence.StatusVocabulary.OwnerLease, as: OwnerLeaseStatus
   alias CodexPooler.Gateway.Persistence.StatusVocabulary.Session, as: SessionStatus
   alias CodexPooler.Gateway.Persistence.StatusVocabulary.Turn, as: TurnStatus
@@ -35,10 +36,12 @@ defmodule CodexPooler.Gateway.Persistence.SessionContinuity.TurnLifecycle do
         %RequestOptions{} = opts
       ) do
     now = now()
+    request_options = opts
     opts = turn_opts(opts)
 
     Repo.transaction(fn ->
       locked_session = codex_session_for_update!(session.id)
+      capture_http_owner!(session, request, request_options)
 
       turn = insert_next_codex_turn!(locked_session, request, opts, now)
 
@@ -276,7 +279,7 @@ defmodule CodexPooler.Gateway.Persistence.SessionContinuity.TurnLifecycle do
 
     if count == 1 do
       turn = Repo.get_by!(CodexTurn, request_id: request_id)
-      maybe_update_session_assignment(turn.codex_session_id, attempt, now)
+      maybe_update_session_assignment(turn, attempt, now)
     end
 
     :ok
@@ -408,7 +411,63 @@ defmodule CodexPooler.Gateway.Persistence.SessionContinuity.TurnLifecycle do
   defp codex_turn_transport_kind("http_compact_json"), do: "http_json"
   defp codex_turn_transport_kind(transport), do: transport
 
-  defp maybe_update_session_assignment(session_id, %Attempt{} = attempt, now) do
+  defp capture_http_owner!(_session, _request, %RequestOptions{
+         transport: %{transport: "websocket"}
+       }),
+       do: :ok
+
+  defp capture_http_owner!(session, request, _opts) do
+    case OwnerLease.validate_for_update(session.id, session.owner_lease_token) do
+      :ok ->
+        fingerprint = owner_fingerprint(session.owner_lease_token)
+
+        Request
+        |> where([stored], stored.id == ^request.id)
+        |> update([stored],
+          set: [
+            request_metadata:
+              fragment(
+                "COALESCE(?, '{}'::jsonb) || jsonb_build_object('http_owner_lease_fingerprint', ?::text)",
+                stored.request_metadata,
+                ^fingerprint
+              )
+          ]
+        )
+        |> Repo.update_all([])
+
+      {:error, reason} ->
+        Repo.rollback(reason)
+    end
+  end
+
+  defp owner_fingerprint(token) when is_binary(token),
+    do: :crypto.hash(:sha256, token) |> Base.encode16(case: :lower)
+
+  defp owner_fingerprint(_token), do: nil
+
+  defp maybe_update_session_assignment(
+         %CodexTurn{transport_kind: "websocket"} = turn,
+         attempt,
+         now
+       ),
+       do: update_session_assignment(turn.codex_session_id, attempt, now)
+
+  defp maybe_update_session_assignment(%CodexTurn{} = turn, attempt, _now) do
+    Repo.transaction(fn ->
+      session = codex_session_for_update!(turn.codex_session_id)
+      request = Repo.get!(Request, turn.request_id)
+      fingerprint = (request.request_metadata || %{})["http_owner_lease_fingerprint"]
+
+      # Only the admitted owner may bind a completed HTTP turn. A digest is
+      # sufficient for this comparison and never exposes a usable lease token.
+      if is_binary(fingerprint) and fingerprint == owner_fingerprint(session.owner_lease_token) and
+           OwnerLease.validate_for_update(session.id, session.owner_lease_token) == :ok do
+        update_session_assignment(session.id, attempt, now())
+      end
+    end)
+  end
+
+  defp update_session_assignment(session_id, %Attempt{} = attempt, now) do
     CodexSession
     |> where([session], session.id == ^session_id)
     |> Repo.update_all(

--- a/lib/codex_pooler/gateway/routing/session_continuity.ex
+++ b/lib/codex_pooler/gateway/routing/session_continuity.ex
@@ -27,7 +27,7 @@ defmodule CodexPooler.Gateway.Routing.SessionContinuity do
   def attach_codex_session(
         auth,
         payload,
-        %RequestOptions{continuity: %{codex_session: %CodexSession{id: session_id}}} =
+        %RequestOptions{continuity: %{codex_session: %CodexSession{} = admitted_session}} =
           request_options
       ) do
     request_options =
@@ -35,15 +35,12 @@ defmodule CodexPooler.Gateway.Routing.SessionContinuity do
       |> ContinuityPayload.put_previous_response_id(payload)
       |> put_previous_response_resolution(auth)
 
-    case start_previous_response_codex_session(auth, request_options) do
-      {:ok, %CodexSession{} = session} ->
-        {:ok, RequestOptions.put_continuity(request_options, codex_session: session)}
-
-      {:error, :session_not_found} ->
-        attach_existing_codex_session(session_id, request_options)
-
-      {:error, reason} ->
-        {:error, reason}
+    with :ok <- validate_admitted_http_owner(admitted_session, request_options) do
+      if request_options.transport.transport == "websocket" do
+        attach_websocket_codex_session(auth, admitted_session, request_options)
+      else
+        attach_existing_codex_session(admitted_session, request_options)
+      end
     end
   end
 
@@ -59,6 +56,19 @@ defmodule CodexPooler.Gateway.Routing.SessionContinuity do
       end
     else
       {:ok, request_options}
+    end
+  end
+
+  defp attach_websocket_codex_session(auth, admitted_session, request_options) do
+    case start_previous_response_codex_session(auth, request_options) do
+      {:ok, %CodexSession{} = session} ->
+        {:ok, RequestOptions.put_continuity(request_options, codex_session: session)}
+
+      {:error, :session_not_found} ->
+        attach_existing_codex_session(admitted_session, request_options)
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -90,7 +100,32 @@ defmodule CodexPooler.Gateway.Routing.SessionContinuity do
     end
   end
 
-  defp attach_existing_codex_session(session_id, request_options) do
+  defp validate_admitted_http_owner(_session, %RequestOptions{
+         transport: %{transport: "websocket"}
+       }),
+       do: :ok
+
+  defp validate_admitted_http_owner(session, _request_options) do
+    case ContinuityStore.validate_owner_token(session.id, session.owner_lease_token) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        {:error,
+         error(409, Atom.to_string(reason), "HTTP session owner lease is unavailable", nil)}
+    end
+  end
+
+  # An explicit HTTP session is an admitted snapshot, not a lookup hint. Keep
+  # its token through reservation so a concurrent takeover is still fenced.
+  defp attach_existing_codex_session(
+         session,
+         %RequestOptions{transport: %{transport: transport}} = opts
+       )
+       when transport != "websocket",
+       do: {:ok, RequestOptions.put_continuity(opts, codex_session: session)}
+
+  defp attach_existing_codex_session(%CodexSession{id: session_id}, request_options) do
     case Repo.get(CodexSession, session_id) do
       %CodexSession{} = session ->
         {:ok, RequestOptions.put_continuity(request_options, codex_session: session)}

--- a/lib/codex_pooler/gateway/runtime/http_owner_lease.ex
+++ b/lib/codex_pooler/gateway/runtime/http_owner_lease.ex
@@ -1,0 +1,134 @@
+defmodule CodexPooler.Gateway.Runtime.HttpOwnerLease do
+  @moduledoc false
+
+  alias CodexPooler.Gateway.OperationalSettings
+  alias CodexPooler.Gateway.Payloads.RequestOptions
+  alias CodexPooler.Gateway.Persistence.{CodexSession, SessionContinuity}
+
+  # HTTP dispatch returns a deferred stream. Keep one heartbeat across both
+  # phases, including time spent waiting for headers or for the first event.
+  def run(%RequestOptions{transport: %{transport: "websocket"}}, callback), do: callback.()
+
+  def run(
+        %RequestOptions{continuity: %{codex_session: %CodexSession{} = session}} = opts,
+        callback
+      ) do
+    case SessionContinuity.renew_owner_token(session, session.owner_lease_token, opts) do
+      {:ok, _session} ->
+        owner = self()
+        interval = heartbeat_interval(opts)
+        lease = {session.id, session.owner_lease_token}
+
+        # The renewal process needs no request body, authorization or routing data.
+        lease_opts =
+          RequestOptions.build(
+            %{bridge_owner_lease_ttl_seconds: opts.continuity.bridge_owner_lease_ttl_seconds},
+            opts.transport.upstream_endpoint,
+            %{}
+          )
+
+        {:ok, heartbeat} =
+          Task.start_link(fn -> heartbeat(owner, lease, lease_opts, interval) end)
+
+        try do
+          case callback.() do
+            {:ok, %{stream: stream} = result} when is_function(stream, 1) ->
+              send(heartbeat, :await_stream)
+
+              {:ok,
+               Map.put(result, :stream, fn conn ->
+                 # Preserve native delivery of an already-dispatched response even
+                 # after owner loss. The original token still fences persistence;
+                 # this message cannot restart an expired or stopped heartbeat.
+                 send(heartbeat, :streaming)
+
+                 try do
+                   stream.(conn)
+                 after
+                   stop(heartbeat)
+                 end
+               end)}
+
+            result ->
+              stop(heartbeat)
+              result
+          end
+        catch
+          kind, reason ->
+            stop(heartbeat)
+            :erlang.raise(kind, reason, __STACKTRACE__)
+        end
+
+      {:error, reason} ->
+        {:error,
+         %{
+           status: 409,
+           code: Atom.to_string(reason),
+           message: "HTTP session owner lease is unavailable",
+           param: nil
+         }}
+    end
+  end
+
+  def run(%RequestOptions{}, callback), do: callback.()
+
+  defp heartbeat(owner, session, opts, interval) do
+    monitor = Process.monitor(owner)
+    heartbeat_loop(owner, monitor, session, opts, interval, nil)
+  end
+
+  defp heartbeat_loop(owner, monitor, session, opts, interval, handoff_deadline) do
+    receive do
+      {:DOWN, ^monitor, :process, ^owner, _reason} ->
+        :ok
+
+      :await_stream ->
+        deadline = System.monotonic_time(:millisecond) + interval * 3
+        heartbeat_loop(owner, monitor, session, opts, interval, deadline)
+
+      :streaming ->
+        heartbeat_loop(owner, monitor, session, opts, interval, nil)
+    after
+      interval ->
+        handoff_expired? =
+          is_integer(handoff_deadline) and
+            System.monotonic_time(:millisecond) >= handoff_deadline
+
+        if Process.alive?(owner) and not handoff_expired? do
+          case renew(session, opts) do
+            {:ok, _session} ->
+              heartbeat_loop(owner, monitor, session, opts, interval, handoff_deadline)
+
+            {:error, _reason} ->
+              :ok
+          end
+        end
+    end
+  end
+
+  # A database failure ends renewal. In particular, never reload a replacement
+  # token or retry an expired lease. Completion still uses its admission fence.
+  defp renew({session_id, owner_lease_token}, opts) do
+    SessionContinuity.renew_owner_token(session_id, owner_lease_token, opts)
+  rescue
+    _error in [DBConnection.ConnectionError, Postgrex.Error] -> {:error, :owner_unavailable}
+  end
+
+  defp stop(heartbeat) do
+    monitor = Process.monitor(heartbeat)
+    Process.unlink(heartbeat)
+    Process.exit(heartbeat, :kill)
+
+    receive do
+      {:DOWN, ^monitor, :process, ^heartbeat, _reason} -> :ok
+    end
+  end
+
+  defp heartbeat_interval(opts) do
+    ttl =
+      opts.continuity.bridge_owner_lease_ttl_seconds ||
+        OperationalSettings.current().bridge_owner_lease_ttl_seconds
+
+    max(div(ttl * 1_000, 3), 1)
+  end
+end

--- a/lib/codex_pooler/gateway/runtime/service.ex
+++ b/lib/codex_pooler/gateway/runtime/service.ex
@@ -16,6 +16,7 @@ defmodule CodexPooler.Gateway.Runtime.Service do
   alias CodexPooler.Gateway.Persistence.CodexSession
   alias CodexPooler.Gateway.Persistence.SessionContinuity, as: PersistenceSessionContinuity
   alias CodexPooler.Gateway.Persistence.SessionContinuity.Aliases, as: SessionAliases
+  alias CodexPooler.Gateway.Persistence.SessionContinuity.OwnerLease
   alias CodexPooler.Gateway.Routing.BridgeRing
   alias CodexPooler.Gateway.Routing.CandidateEligibility
   alias CodexPooler.Gateway.Routing.ModelMetadata
@@ -30,6 +31,7 @@ defmodule CodexPooler.Gateway.Runtime.Service do
   alias CodexPooler.Gateway.Runtime.Dispatch.RouteState
   alias CodexPooler.Gateway.Runtime.Dispatch.SelectedCandidateContext
   alias CodexPooler.Gateway.Runtime.Dispatch.UpstreamAttempt
+  alias CodexPooler.Gateway.Runtime.HttpOwnerLease
   alias CodexPooler.Gateway.Transports.Admission
   alias CodexPooler.Gateway.Transports.Streaming.PreparedWebsocketFrame
   alias CodexPooler.Gateway.Transports.Streaming.PreparedWebsocketFrame.ValidationClaim
@@ -498,7 +500,9 @@ defmodule CodexPooler.Gateway.Runtime.Service do
         reserve_and_start_turn
       )
       when is_list(candidates) and is_function(reserve_and_start_turn, 8) do
-    do_execute_session_routable_model(context, reserve_and_start_turn)
+    HttpOwnerLease.run(context.request_options, fn ->
+      do_execute_session_routable_model(context, reserve_and_start_turn)
+    end)
   end
 
   defp do_execute_session_routable_model(
@@ -1857,6 +1861,17 @@ defmodule CodexPooler.Gateway.Runtime.Service do
            request_options
        ) do
     locked_session = PersistenceSessionContinuity.lock_codex_session_for_turn(session)
+
+    if request_options.transport.transport != "websocket" do
+      case OwnerLease.validate_for_update(
+             session.id,
+             session.owner_lease_token
+           ) do
+        :ok -> :ok
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end
+
     RequestOptions.put_continuity(request_options, codex_session: locked_session)
   end
 

--- a/test/codex_pooler/gateway/persistence/http_owner_lease_locking_test.exs
+++ b/test/codex_pooler/gateway/persistence/http_owner_lease_locking_test.exs
@@ -1,0 +1,99 @@
+defmodule CodexPooler.Gateway.Persistence.HttpOwnerLeaseLockingTest do
+  use CodexPooler.DataCase, async: false
+
+  import CodexPooler.AccountsFixtures, only: [reset_bootstrap_state_fixture!: 0]
+  import CodexPooler.PoolerFixtures
+
+  alias CodexPooler.Gateway.Payloads.RequestOptions
+  alias CodexPooler.Gateway.Persistence.{BridgeOwnerLease, CodexSession, SessionContinuity}
+  alias Ecto.Adapters.SQL.Sandbox
+
+  test "renewal blocked on the session row checks expiry after obtaining its locks" do
+    {session, opts} =
+      Sandbox.unboxed_run(Repo, fn ->
+        reset_bootstrap_state_fixture!()
+        %{pool: pool, api_key: api_key} = active_api_key_fixture()
+
+        opts =
+          RequestOptions.build(
+            %{session_header: Ecto.UUID.generate(), bridge_owner_lease_ttl_seconds: 1},
+            "/backend-api/codex/responses",
+            %{}
+          )
+
+        {:ok, session} =
+          SessionContinuity.start_codex_session(%{pool: pool, api_key: api_key}, opts)
+
+        {session, opts}
+      end)
+
+    parent = self()
+
+    blocker =
+      Task.async(fn ->
+        Sandbox.unboxed_run(Repo, fn ->
+          Repo.transaction(fn ->
+            Repo.one!(from s in CodexSession, where: s.id == ^session.id, lock: "FOR UPDATE")
+            send(parent, :row_locked)
+
+            receive do
+              :unlock -> :ok
+            end
+          end)
+        end)
+      end)
+
+    assert_receive :row_locked
+
+    renewal =
+      Task.async(fn ->
+        Sandbox.unboxed_run(Repo, fn ->
+          %{rows: [[pid]]} = Repo.query!("SELECT pg_backend_pid()")
+          send(parent, {:renewal_backend, pid})
+          SessionContinuity.renew_owner_token(session, session.owner_lease_token, opts)
+        end)
+      end)
+
+    try do
+      assert_receive {:renewal_backend, backend}
+      await_blocked(backend, 100)
+
+      remaining =
+        max(DateTime.diff(session.owner_lease_expires_at, DateTime.utc_now(), :millisecond), 0)
+
+      Process.sleep(remaining + 100)
+      send(blocker.pid, :unlock)
+      Task.await(blocker)
+      assert {:error, :owner_unavailable} = Task.await(renewal)
+
+      Sandbox.unboxed_run(Repo, fn ->
+        assert Repo.reload!(session) == session
+
+        assert Repo.get_by!(BridgeOwnerLease, codex_session_id: session.id).expires_at ==
+                 session.owner_lease_expires_at
+      end)
+    after
+      send(blocker.pid, :unlock)
+      Task.shutdown(blocker, :brutal_kill)
+      Task.shutdown(renewal, :brutal_kill)
+      Sandbox.unboxed_run(Repo, fn -> reset_bootstrap_state_fixture!() end)
+    end
+  end
+
+  defp await_blocked(_backend, 0), do: flunk("renewal never waited on the session row lock")
+
+  defp await_blocked(backend, retries) do
+    blocked? =
+      Sandbox.unboxed_run(Repo, fn ->
+        %{rows: [[blocked?]]} =
+          Repo.query!("SELECT cardinality(pg_blocking_pids($1)) > 0", [backend])
+
+        blocked?
+      end)
+
+    unless blocked? do
+      Process.sleep(10)
+      await_blocked(backend, retries - 1)
+    end
+  end
+end

--- a/test/codex_pooler/gateway/persistence/http_owner_lease_test.exs
+++ b/test/codex_pooler/gateway/persistence/http_owner_lease_test.exs
@@ -1,0 +1,302 @@
+defmodule CodexPooler.Gateway.Persistence.HttpOwnerLeaseTest do
+  use CodexPooler.DataCase, async: false
+
+  import CodexPooler.PoolerFixtures
+
+  alias CodexPooler.Gateway.Payloads.RequestOptions
+
+  alias CodexPooler.Gateway.Persistence.{
+    BridgeOwnerLease,
+    BridgeSessionAlias,
+    CodexTurn,
+    SessionContinuity
+  }
+
+  alias CodexPooler.Gateway.Runtime.HttpOwnerLease
+
+  setup do
+    %{pool: pool, api_key: api_key} = active_api_key_fixture()
+    auth = %{pool: pool, api_key: api_key}
+
+    opts =
+      RequestOptions.from_conn_metadata(
+        %{session_key: Ecto.UUID.generate(), bridge_owner_lease_ttl_seconds: 1},
+        "/backend-api/codex/responses",
+        %{}
+      )
+
+    {:ok, session} = SessionContinuity.start_codex_session(auth, opts)
+    opts = RequestOptions.put_continuity(opts, codex_session: session)
+    %{auth: auth, session: session, opts: opts}
+  end
+
+  test "HTTP completion renews both deadlines and next same-key turn retains its session and assignment",
+       ctx do
+    %{assignment: assignment} = active_upstream_assignment_fixture(ctx.auth.pool)
+    opts = RequestOptions.put_file_bridge(ctx.opts, pool_upstream_assignment_id: assignment.id)
+    set_expiry(ctx.session, DateTime.add(DateTime.utc_now(), 200, :millisecond))
+
+    assert :ok = SessionContinuity.register_codex_session_continuity(ctx.session, %{}, %{}, opts)
+    renewed = Repo.reload!(ctx.session)
+    assert renewed.owner_lease_expires_at == lease(ctx.session).expires_at
+    Process.sleep(250)
+    assert {:ok, attached} = SessionContinuity.start_codex_session(ctx.auth, ctx.opts)
+    assert attached.id == ctx.session.id
+    assert attached.pool_upstream_assignment_id == assignment.id
+  end
+
+  test "expired completion cannot resurrect either deadline or register aliases", ctx do
+    set_expiry(ctx.session, DateTime.add(DateTime.utc_now(), -1, :second))
+    before = Repo.reload!(ctx.session)
+    before_lease = lease(ctx.session)
+
+    assert {:error, :owner_unavailable} =
+             SessionContinuity.register_codex_session_continuity(
+               ctx.session,
+               %{},
+               %{"id" => "late-response"},
+               ctx.opts
+             )
+
+    assert Repo.reload!(ctx.session) == before
+    assert lease(ctx.session) == before_lease
+
+    refute Repo.exists?(
+             from a in BridgeSessionAlias, where: a.alias_kind == "previous_response_id"
+           )
+  end
+
+  test "old completion cannot bind or renew the replacement owner's session", ctx do
+    %{assignment: assignment} = active_upstream_assignment_fixture(ctx.auth.pool)
+    opts = RequestOptions.put_file_bridge(ctx.opts, pool_upstream_assignment_id: assignment.id)
+
+    {:ok, replacement} =
+      SessionContinuity.replace_unavailable_owner_lease(
+        ctx.session,
+        RequestOptions.put_continuity(ctx.opts, owner_instance_id: "replacement")
+      )
+
+    before_lease = lease(ctx.session)
+
+    assert {:error, :stale_owner} =
+             SessionContinuity.register_codex_session_continuity(
+               ctx.session,
+               %{},
+               %{"id" => "old-response"},
+               opts
+             )
+
+    assert Repo.reload!(ctx.session) == replacement
+    assert lease(ctx.session) == before_lease
+
+    refute Repo.exists?(
+             from a in BridgeSessionAlias, where: a.alias_kind == "previous_response_id"
+           )
+  end
+
+  test "silent dispatch outlives the TTL and active attach retains ownership", ctx do
+    result =
+      HttpOwnerLease.run(ctx.opts, fn ->
+        Process.sleep(1_250)
+
+        assert :ok =
+                 SessionContinuity.validate_owner_token(
+                   ctx.session,
+                   ctx.session.owner_lease_token
+                 )
+
+        assert {:ok, attached} = SessionContinuity.start_codex_session(ctx.auth, ctx.opts)
+        assert attached.id == ctx.session.id
+        assert attached.owner_lease_token == ctx.session.owner_lease_token
+        {:ok, :complete}
+      end)
+
+    assert result == {:ok, :complete}
+    assert_eventually_expired(ctx.session)
+  end
+
+  test "heartbeat spans deferred SSE silence and stops after cancellation", ctx do
+    assert {:ok, %{stream: stream}} =
+             HttpOwnerLease.run(ctx.opts, fn ->
+               Process.sleep(700)
+
+               {:ok,
+                %{
+                  stream: fn _conn ->
+                    Process.sleep(700)
+
+                    assert :ok =
+                             SessionContinuity.validate_owner_token(
+                               ctx.session,
+                               ctx.session.owner_lease_token
+                             )
+
+                    {:error, :client_disconnected}
+                  end
+                }}
+             end)
+
+    Process.sleep(400)
+    assert {:error, :client_disconnected} = stream.(:conn)
+    assert_eventually_expired(ctx.session)
+  end
+
+  test "dispatch and stream exceptions stop their heartbeat", ctx do
+    assert_raise RuntimeError, "dispatch failed", fn ->
+      HttpOwnerLease.run(ctx.opts, fn -> raise "dispatch failed" end)
+    end
+
+    assert_eventually_expired(ctx.session)
+
+    {:ok, session} = SessionContinuity.start_codex_session(ctx.auth, ctx.opts)
+    opts = RequestOptions.put_continuity(ctx.opts, codex_session: session)
+
+    {:ok, %{stream: stream}} =
+      HttpOwnerLease.run(opts, fn ->
+        {:ok, %{stream: fn _conn -> raise "stream failed" end}}
+      end)
+
+    assert_raise RuntimeError, "stream failed", fn -> stream.(:conn) end
+    assert_eventually_expired(session)
+  end
+
+  test "request process death stops renewal even if a stream was never consumed", ctx do
+    parent = self()
+
+    pid =
+      spawn(fn ->
+        HttpOwnerLease.run(ctx.opts, fn ->
+          {:ok, %{stream: fn _conn -> :ok end}}
+        end)
+
+        send(parent, :stream_abandoned)
+
+        receive do
+          :never -> :ok
+        end
+      end)
+
+    assert_receive :stream_abandoned
+    Process.exit(pid, :kill)
+    assert_eventually_expired(ctx.session)
+  end
+
+  test "heartbeat does not renew or acquire a new token after takeover", ctx do
+    {:ok, %{stream: stream}} =
+      HttpOwnerLease.run(ctx.opts, fn ->
+        {:ok, %{stream: fn _conn -> :ok end}}
+      end)
+
+    {:ok, replacement} =
+      SessionContinuity.replace_unavailable_owner_lease(
+        ctx.session,
+        RequestOptions.put_continuity(ctx.opts, owner_instance_id: "replacement")
+      )
+
+    before_lease = lease(ctx.session)
+    Process.sleep(450)
+    assert Repo.reload!(ctx.session) == replacement
+    assert lease(ctx.session) == before_lease
+    assert :ok = stream.(:conn)
+  end
+
+  test "stale HTTP turn start cannot adopt a replacement token", ctx do
+    {:ok, _replacement} = SessionContinuity.replace_unavailable_owner_lease(ctx.session, ctx.opts)
+    request = request_fixture(ctx.auth, %{status: "in_progress", completed_at: nil})
+
+    assert {:error, :stale_owner} =
+             SessionContinuity.start_codex_turn(ctx.session, request, ctx.opts)
+
+    refute Repo.exists?(CodexTurn)
+  end
+
+  test "old HTTP attempt settlement cannot overwrite a replacement assignment", ctx do
+    %{assignment: assignment} = active_upstream_assignment_fixture(ctx.auth.pool)
+    request = request_fixture(ctx.auth, %{status: "in_progress", completed_at: nil})
+    {:ok, turn} = SessionContinuity.start_codex_turn(ctx.session, request, ctx.opts)
+    attempt = attempt_fixture(request, assignment)
+    {:ok, replacement} = SessionContinuity.replace_unavailable_owner_lease(ctx.session, ctx.opts)
+    before_lease = lease(ctx.session)
+    result = {:ok, %{request: request, attempt: attempt}}
+    assert ^result = SessionContinuity.complete_codex_turn(result, "succeeded", nil)
+    assert Repo.reload!(turn).status == "succeeded"
+    assert Repo.reload!(ctx.session) == replacement
+    assert lease(ctx.session) == before_lease
+    refute inspect(Repo.reload!(request).request_metadata) =~ ctx.session.owner_lease_token
+  end
+
+  test "current HTTP attempt binds its account and preserves newer request metadata", ctx do
+    %{assignment: assignment} = active_upstream_assignment_fixture(ctx.auth.pool)
+    request = request_fixture(ctx.auth, %{status: "in_progress", completed_at: nil})
+
+    request
+    |> Ecto.Changeset.change(request_metadata: %{"concurrent_key" => "retained"})
+    |> Repo.update!()
+
+    {:ok, _turn} = SessionContinuity.start_codex_turn(ctx.session, request, ctx.opts)
+    attempt = attempt_fixture(request, assignment)
+    result = {:ok, %{request: request, attempt: attempt}}
+    assert ^result = SessionContinuity.complete_codex_turn(result, "succeeded", nil)
+    assert Repo.reload!(ctx.session).pool_upstream_assignment_id == assignment.id
+    assert lease(ctx.session).pool_upstream_assignment_id == assignment.id
+    assert Repo.reload!(request).request_metadata["concurrent_key"] == "retained"
+  end
+
+  test "explicit HTTP snapshot cannot adopt a replacement owner during attach", ctx do
+    {:ok, replacement} = SessionContinuity.replace_unavailable_owner_lease(ctx.session, ctx.opts)
+
+    assert {:error, %{code: "stale_owner"}} =
+             CodexPooler.Gateway.Routing.SessionContinuity.attach_codex_session(
+               ctx.auth,
+               %{},
+               ctx.opts
+             )
+
+    assert Repo.reload!(ctx.session) == replacement
+  end
+
+  test "late consumption preserves native delivery without resurrecting abandoned ownership",
+       ctx do
+    {:ok, %{stream: stream}} =
+      HttpOwnerLease.run(ctx.opts, fn ->
+        {:ok,
+         %{
+           stream: fn _conn ->
+             assert {:error, :owner_unavailable} =
+                      SessionContinuity.register_codex_session_continuity(
+                        ctx.session,
+                        %{},
+                        %{},
+                        ctx.opts
+                      )
+
+             {:ok, :already_generated_response}
+           end
+         }}
+      end)
+
+    Process.sleep(1_150)
+    assert_eventually_expired(ctx.session)
+    before = Repo.reload!(ctx.session)
+    assert {:ok, :already_generated_response} = stream.(:conn)
+    assert Repo.reload!(ctx.session) == before
+  end
+
+  defp lease(session),
+    do: Repo.get_by!(BridgeOwnerLease, codex_session_id: session.id, status: "active")
+
+  defp set_expiry(session, expiry) do
+    expiry = DateTime.truncate(expiry, :microsecond)
+    session |> Ecto.Changeset.change(owner_lease_expires_at: expiry) |> Repo.update!()
+    lease(session) |> Ecto.Changeset.change(expires_at: expiry) |> Repo.update!()
+  end
+
+  defp assert_eventually_expired(session) do
+    before = Repo.reload!(session)
+    Process.sleep(1_100)
+    assert Repo.reload!(session) == before
+
+    assert {:error, :owner_unavailable} =
+             SessionContinuity.validate_owner_token(session, session.owner_lease_token)
+  end
+end

--- a/test/codex_pooler/gateway/routing/session_continuity_test.exs
+++ b/test/codex_pooler/gateway/routing/session_continuity_test.exs
@@ -615,7 +615,17 @@ defmodule CodexPooler.Gateway.Routing.SessionContinuityTest do
       setup = active_pinned_assignment_setup()
       api_key = active_api_key_fixture(setup.pool)
       {:ok, auth} = Access.authenticate_authorization_header(api_key.authorization)
-      session = codex_session_fixture(setup, setup.pinned.assignment, api_key.api_key)
+
+      {:ok, session} =
+        CodexPooler.Gateway.Persistence.SessionContinuity.start_codex_session(
+          auth,
+          RequestOptions.build(%{session_header: Ecto.UUID.generate()}, @endpoint, %{})
+        )
+
+      session =
+        session
+        |> Ecto.Changeset.change(pool_upstream_assignment_id: setup.pinned.assignment.id)
+        |> Repo.update!()
 
       model =
         model_for_assignments(setup.pool, [setup.pinned.assignment.id, setup.other.assignment.id])
@@ -671,7 +681,7 @@ defmodule CodexPooler.Gateway.Routing.SessionContinuityTest do
 
       opts =
         %{api_key_policy: auth.api_key}
-        |> RequestOptions.build(@endpoint, payload)
+        |> RequestOptions.for_websocket(payload)
         |> RequestOptions.put_continuity(codex_session: attached_session)
 
       assert {:ok, %{request_options: prepared_opts, candidates: candidates}} =

--- a/test/codex_pooler/gateway/runtime/http_owner_lease_integration_test.exs
+++ b/test/codex_pooler/gateway/runtime/http_owner_lease_integration_test.exs
@@ -1,0 +1,133 @@
+defmodule CodexPooler.Gateway.Runtime.HttpOwnerLeaseIntegrationTest do
+  use CodexPoolerWeb.ConnCase, async: false
+
+  import CodexPoolerWeb.Runtime.BackendCodexTestSupport,
+    only: [gateway_setup: 1, start_upstream: 1]
+
+  alias CodexPooler.{Access, FakeUpstream, Gateway, Repo}
+  alias CodexPooler.Gateway.Payloads.RequestOptions
+  alias CodexPooler.Gateway.Persistence.{BridgeOwnerLease, CodexSession, SessionContinuity}
+
+  @endpoint "/backend-api/codex/responses"
+  @response %{
+    "id" => "resp_lease",
+    "output" => [],
+    "usage" => %{"input_tokens" => 1, "output_tokens" => 1, "total_tokens" => 2}
+  }
+
+  test "real HTTP request retains the session beyond TTL while waiting for response headers" do
+    ref = make_ref()
+
+    upstream =
+      start_upstream(
+        FakeUpstream.barrier_json_response(@response, notify: self(), release_ref: ref)
+      )
+
+    setup = gateway_setup(upstream)
+    {:ok, auth} = Access.authenticate_authorization_header(setup.authorization)
+    payload = payload(setup, false)
+    opts = options(payload)
+
+    task = Task.async(fn -> Gateway.execute(auth, @endpoint, payload, opts) end)
+    assert_receive {:fake_upstream_timeout_barrier, :before_headers, handler, ^ref}, 5_000
+
+    try do
+      session = Repo.one!(CodexSession)
+      Process.sleep(1_250)
+      assert_active(session)
+      assert {:ok, attached} = SessionContinuity.start_codex_session(auth, opts)
+      assert attached.id == session.id
+      send(handler, {:fake_upstream_release_timeout, ref})
+      assert {:ok, %{status: 200}} = Task.await(task, 5_000)
+      assert Repo.reload!(session).pool_upstream_assignment_id == setup.assignment.id
+      assert_same_key_reconnect(auth, opts, session, setup.assignment.id)
+    after
+      send(handler, {:fake_upstream_release_timeout, ref})
+      Task.shutdown(task, :brutal_kill)
+    end
+  end
+
+  test "real HTTP SSE keeps the owner through a silent interval and terminal finalization", %{
+    conn: conn
+  } do
+    ref = make_ref()
+
+    events = [
+      %{"type" => "response.created", "response" => %{"id" => "resp_lease"}},
+      %{"type" => "response.completed", "response" => @response}
+    ]
+
+    upstream =
+      start_upstream(
+        FakeUpstream.barrier_sse_stream(events,
+          notify: self(),
+          release_ref: ref,
+          barrier_after: 1,
+          done: false
+        )
+      )
+
+    setup = gateway_setup(upstream)
+    {:ok, auth} = Access.authenticate_authorization_header(setup.authorization)
+    payload = payload(setup, true)
+    opts = options(payload)
+    parent = self()
+
+    task =
+      Task.async(fn ->
+        {:ok, %{stream: stream}} = Gateway.execute(auth, @endpoint, payload, opts)
+        send(parent, :stream_returned)
+        stream.(Plug.Conn.send_chunked(conn, 200))
+      end)
+
+    assert_receive {:fake_upstream_chunk_barrier, 1, handler, ^ref}, 5_000
+
+    try do
+      assert_receive :stream_returned, 5_000
+      session = Repo.one!(CodexSession)
+      Process.sleep(1_250)
+      assert_active(session)
+      send(handler, {:fake_upstream_release_chunk, ref})
+      assert {:ok, _conn} = Task.await(task, 5_000)
+      assert Repo.reload!(session).pool_upstream_assignment_id == setup.assignment.id
+      assert_same_key_reconnect(auth, opts, session, setup.assignment.id)
+    after
+      send(handler, {:fake_upstream_release_chunk, ref})
+      Task.shutdown(task, :brutal_kill)
+    end
+  end
+
+  defp assert_active(session) do
+    assert :ok = SessionContinuity.validate_owner_token(session, session.owner_lease_token)
+    current = Repo.reload!(session)
+    lease = Repo.get_by!(BridgeOwnerLease, codex_session_id: session.id, status: "active")
+    assert current.owner_lease_expires_at == lease.expires_at
+  end
+
+  defp assert_same_key_reconnect(auth, opts, session, assignment_id) do
+    assert {:ok, next} = SessionContinuity.start_codex_session(auth, opts)
+    assert next.id == session.id
+    assert next.pool_upstream_assignment_id == assignment_id
+    assert Repo.aggregate(CodexSession, :count) == 1
+  end
+
+  defp payload(setup, stream),
+    do: %{
+      "model" => setup.model.exposed_model_id,
+      "input" => [
+        %{
+          "role" => "user",
+          "content" => [%{"type" => "input_text", "text" => "synthetic lease probe"}]
+        }
+      ],
+      "stream" => stream
+    }
+
+  defp options(payload),
+    do:
+      RequestOptions.build(
+        %{session_header: Ecto.UUID.generate(), bridge_owner_lease_ttl_seconds: 1},
+        @endpoint,
+        payload
+      )
+end

--- a/test/codex_pooler/gateway/runtime/pre_dispatch_test.exs
+++ b/test/codex_pooler/gateway/runtime/pre_dispatch_test.exs
@@ -25,6 +25,7 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch.PreDispatchTest do
   alias CodexPooler.Gateway.Metadata.CodexCatalog
   alias CodexPooler.Gateway.Payloads.RequestOptions
   alias CodexPooler.Gateway.Persistence.CodexSession
+  alias CodexPooler.Gateway.Persistence.SessionContinuity
   alias CodexPooler.Gateway.Routing.CandidateEligibility
   alias CodexPooler.Gateway.Routing.PartitionRoutability
   alias CodexPooler.Gateway.Runtime.Dispatch.PreDispatch
@@ -1549,19 +1550,8 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch.PreDispatchTest do
     setup = gateway_setup(start_upstream(FakeUpstream.json_response(%{"data" => []})))
     {model, divergent} = add_divergent_assignment!(setup)
     {:ok, auth} = Access.authenticate_authorization_header(setup.authorization)
-    now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
 
-    session =
-      %CodexSession{
-        pool_id: setup.pool.id,
-        api_key_id: auth.api_key.id,
-        session_key: "partition-session-#{System.unique_integer([:positive])}",
-        pool_upstream_assignment_id: divergent.assignment.id,
-        status: "active",
-        created_at: now,
-        updated_at: now
-      }
-      |> Repo.insert!()
+    session = admitted_session!(auth, divergent.assignment.id)
 
     payload = %{
       "model" => model.exposed_model_id,
@@ -1636,7 +1626,6 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch.PreDispatchTest do
   test "a hard-pinned continuation rejects an assignment with malformed canonical source metadata" do
     setup = gateway_setup(start_upstream(FakeUpstream.json_response(%{"data" => []})))
     {:ok, auth} = Access.authenticate_authorization_header(setup.authorization)
-    now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
 
     model =
       setup.model
@@ -1648,17 +1637,7 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch.PreDispatchTest do
       })
       |> Repo.update!()
 
-    session =
-      %CodexSession{
-        pool_id: setup.pool.id,
-        api_key_id: auth.api_key.id,
-        session_key: "invalid-partition-session-#{System.unique_integer([:positive])}",
-        pool_upstream_assignment_id: setup.assignment.id,
-        status: "active",
-        created_at: now,
-        updated_at: now
-      }
-      |> Repo.insert!()
+    session = admitted_session!(auth, setup.assignment.id)
 
     payload = %{
       "model" => model.exposed_model_id,
@@ -2652,6 +2631,16 @@ defmodule CodexPooler.Gateway.Runtime.Dispatch.PreDispatchTest do
         |> Map.put("source_assignment_models", source_models)
     })
     |> Repo.update!()
+  end
+
+  defp admitted_session!(auth, assignment_id) do
+    {:ok, session} =
+      SessionContinuity.start_codex_session(
+        auth,
+        RequestOptions.build(%{session_header: Ecto.UUID.generate()}, @endpoint_path, %{})
+      )
+
+    session |> Ecto.Changeset.change(pool_upstream_assignment_id: assignment_id) |> Repo.update!()
   end
 
   defp add_divergent_assignment!(setup) do

--- a/test/codex_pooler/gateway/runtime/saved_reset_capacity_fence_test.exs
+++ b/test/codex_pooler/gateway/runtime/saved_reset_capacity_fence_test.exs
@@ -9,7 +9,7 @@ defmodule CodexPooler.Gateway.Runtime.SavedResetCapacityFenceTest do
   alias CodexPooler.Access
   alias CodexPooler.FakeUpstream
   alias CodexPooler.Gateway.Payloads.RequestOptions
-  alias CodexPooler.Gateway.Persistence.CodexSession
+  alias CodexPooler.Gateway.Persistence.SessionContinuity
   alias CodexPooler.Gateway.Routing.CandidateEligibility
   alias CodexPooler.Gateway.Routing.RouteFiltering
   alias CodexPooler.Gateway.Routing.SavedResetAutoRedeem
@@ -225,22 +225,18 @@ defmodule CodexPooler.Gateway.Runtime.SavedResetCapacityFenceTest do
     end
   end
 
-  defp active_session!(setup, auth, assignment_id) do
-    now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+  defp active_session!(_setup, auth, assignment_id) do
+    {:ok, session} =
+      SessionContinuity.start_codex_session(
+        auth,
+        RequestOptions.build(
+          %{session_header: Ecto.UUID.generate(), owner_instance_id: "capacity-fence-test"},
+          @endpoint,
+          %{}
+        )
+      )
 
-    Repo.insert!(%CodexSession{
-      pool_id: setup.pool.id,
-      api_key_id: auth.api_key.id,
-      session_key: "capacity-fence-#{System.unique_integer([:positive])}",
-      pool_upstream_assignment_id: assignment_id,
-      status: "active",
-      owner_instance_id: "capacity-fence-test",
-      owner_lease_token: Ecto.UUID.generate(),
-      owner_lease_expires_at: DateTime.add(now, 1, :hour),
-      last_heartbeat_at: now,
-      created_at: now,
-      updated_at: now
-    })
+    session |> Ecto.Changeset.change(pool_upstream_assignment_id: assignment_id) |> Repo.update!()
   end
 
   defp put_saved_reset_metadata!(identity, upstream) do


### PR DESCRIPTION
HTTP requests with a Codex session can outlive their owner lease while waiting for headers or SSE data. Successful continuity registration currently renews `bridge_owner_leases.expires_at` without renewing `codex_sessions.owner_lease_expires_at`. The next same-key request can close the session, create a new UUID and lose its account preference. Renewal also samples time before waiting for row locks, allowing an expired owner to renew after a long lock wait.

This change renews both deadlines atomically using the admitted token and checks expiry after acquiring the session/lease locks. A request-scoped heartbeat covers HTTP dispatch and deferred SSE consumption in the current synchronous controller lifecycle, and stops on completion, cancellation, caller death, ownership loss or database failure. Abandoned deferred-stream handoff is bounded by the existing lease TTL. Explicit HTTP session snapshots and turn-completion writes are fenced against replacement owners; the persisted turn witness is a SHA-256 fingerprint, never a usable lease token.

The current lease TTL and WebSocket heartbeat remain unchanged. Native delivery of an already-dispatched response remains possible after ownership loss, but its stale completion cannot renew or overwrite replacement session state. This does not add durable affinity across intentional idle expiry or promise provider prompt-cache hits.

Validation uses Elixir 1.20.4 / OTP 29.0.6 and disposable PostgreSQL 18 with synthetic upstreams only. New real HTTP/SSE and independent-connection lock-wait regressions all fail against `ab6ea489` and pass with the fix. Existing routing fixtures now create actual session leases while preserving their original HTTP/HTTP-via-WebSocket scenarios.

Validation:

- Ordinary suite on the reviewed patch snapshot: **8,501/8,508 passed**; the seven failures are database-name assertions caused by my isolated database-name override. The same seven fail on pristine `ab6ea489` (8,485/8,492 passed). Rerunning all seven with the default database name: **7/7 passed**.
- Final source, after narrowing heartbeat capture to session ID/token and TTL options: **858/858** persistence, runtime, routing and database-configuration tests passed. The full-suite snapshot otherwise differs only by equivalent `with`/`case` syntax, alias formatting and unconditional test cleanup.
- Required Unix integration profile: **59/59 passed**.
- The three new end-to-end HTTP/SSE and row-lock regressions fail on pristine upstream and pass with the patch; **16 new tests** cover renewal, takeover fencing and heartbeat lifecycle.
- Compilation with warnings as errors, formatting, xref and strict Credo passed. Independent source review found no blocking issue.

No schema migration or operational setting change is required.
