### PR TITLE
feat: preserve optional conversation account affinity across idle sessions

### DIFF
--- a/docs-site/src/content/docs/operators/pools.mdx
+++ b/docs-site/src/content/docs/operators/pools.mdx
@@ -223,6 +223,47 @@ Routing settings are split into selection policy, continuity, and compatibility.
 
 `Prompt cache affinity` keeps related prompt-cache-key requests near the same upstream for routing locality. Codex Pooler uses this as a routing input only. It does not store prompts or responses for this control.
 
+`Durable conversation affinity` is off by default. When enabled, a conversation
+prefers the same eligible account after an idle reconnect, a recreated Pooler
+session, or routing through another Pooler replica. The PostgreSQL mapping is
+scoped to the Pool, API key, exposed model, and typed client identifier.
+
+For HTTP and websocket upgrade requests, send a stable `thread-id` header
+(preferred), or `x-codex-conversation-id`. Keep its value unchanged when resuming
+that conversation. Internal callers may supply an explicit `conversation_key`.
+Codex sends `thread-id`; its `session-id` can be shared by a root and its child
+threads, so session headers alone do not enable this mapping. Window identifiers,
+turn-state tokens, request IDs, prompt-cache keys, and generated Pooler session
+UUIDs are also not durable conversation identifiers. Missing, blank, oversized
+(over 1024 bytes), or duplicate selected headers do not produce a durable key.
+Changing the identifier or its header type starts a separate mapping.
+
+The initial route still respects prompt-cache locality. A successful failover
+changes the remembered account; recovery of the old account does not switch the
+conversation back. Concurrent completions use a database generation fence, so a
+late completion cannot undo that change. An existing soft session preference
+cannot override the durable choice. Quota, health and assignment eligibility,
+previous-response and file constraints, and active upstream websocket pins retain
+their existing priority. Durable affinity neither restores an excluded candidate
+nor adds retries that the request otherwise disallows.
+
+`Conversation affinity idle retention (seconds)` defaults to `86400` (one day),
+with a range of `60` to `2592000` (30 days). Creation starts the retention period;
+only successful completions renew it. Failed attempts and reads do not extend it.
+Expired mappings are ignored immediately and the runtime cleanup job deletes up
+to 1000 expired mappings per run. A new request can replace its own expired row
+before that cleanup runs. Disabling affects new route plans; already admitted
+plans may complete their fenced bookkeeping. Retained rows otherwise expire
+normally. Saving a retention change affects new mappings and subsequent
+successful renewals. It does not retroactively extend existing rows, and a
+shorter retention never shortens an already later expiry.
+
+Only a typed, scoped digest and account routing metadata enter the durable row;
+this feature does not add raw identifiers to request logs or metrics. The outgoing
+payload and `prompt_cache_key` are unchanged. Same-account routing can improve
+locality, but does not guarantee provider cache hits, saved tokens, or portability
+of provider state between accounts.
+
 ### Compatibility
 
 `Allow /v1 compatibility` enables OpenAI-style `/v1` compatibility routes for clients that use that surface.

--- a/lib/codex_pooler/admin/pool_workflow.ex
+++ b/lib/codex_pooler/admin/pool_workflow.ex
@@ -172,6 +172,10 @@ defmodule CodexPooler.Admin.PoolWorkflow do
       "bridge_ring_size" => Map.get(attrs, "bridge_ring_size", 3),
       "sticky_websocket_sessions" => Map.get(attrs, "sticky_websocket_sessions", true),
       "sticky_http_sessions" => Map.get(attrs, "sticky_http_sessions", false),
+      "durable_conversation_affinity_enabled" =>
+        Map.get(attrs, "durable_conversation_affinity_enabled", false),
+      "durable_conversation_affinity_idle_seconds" =>
+        Map.get(attrs, "durable_conversation_affinity_idle_seconds", 86_400),
       "prompt_cache_affinity_enabled" => Map.get(attrs, "prompt_cache_affinity_enabled", true),
       "v1_compatibility_enabled" => Map.get(attrs, "v1_compatibility_enabled", true),
       "request_compression_enabled" => Map.get(attrs, "request_compression_enabled", false),

--- a/lib/codex_pooler/gateway/payloads/request_options.ex
+++ b/lib/codex_pooler/gateway/payloads/request_options.ex
@@ -105,6 +105,7 @@ defmodule CodexPooler.Gateway.Payloads.RequestOptions do
     :compaction_result_mode,
     :compaction_result_transport,
     :conversation_key,
+    :durable_conversation_key_hash,
     :connect_timeout,
     :connect_timeout_ms,
     :bridge_owner_lease_ttl_seconds,

--- a/lib/codex_pooler/gateway/payloads/request_options/continuity.ex
+++ b/lib/codex_pooler/gateway/payloads/request_options/continuity.ex
@@ -1,6 +1,7 @@
 defmodule CodexPooler.Gateway.Payloads.RequestOptions.Continuity do
   @moduledoc false
 
+  alias CodexPooler.Gateway.Payloads.RequestOptions.ConversationAffinity
   alias CodexPooler.Gateway.Payloads.RequestOptions.Normalization
 
   @session_header_sources [
@@ -22,6 +23,7 @@ defmodule CodexPooler.Gateway.Payloads.RequestOptions.Continuity do
     :session_header_source,
     :session_key,
     :conversation_key,
+    :durable_conversation_key_hash,
     :owner_instance_id,
     :bridge_owner_lease_ttl_seconds,
     :reconnect_window_seconds,
@@ -43,6 +45,7 @@ defmodule CodexPooler.Gateway.Payloads.RequestOptions.Continuity do
           session_header_source: String.t() | nil,
           session_key: String.t() | nil,
           conversation_key: String.t() | nil,
+          durable_conversation_key_hash: <<_::256>> | nil,
           owner_instance_id: String.t() | nil,
           bridge_owner_lease_ttl_seconds: pos_integer() | nil,
           reconnect_window_seconds: non_neg_integer() | nil,
@@ -67,6 +70,7 @@ defmodule CodexPooler.Gateway.Payloads.RequestOptions.Continuity do
       session_header_source: session_header_source(Map.get(opts, :session_header_source)),
       session_key: Map.get(opts, :session_key),
       conversation_key: Map.get(opts, :conversation_key),
+      durable_conversation_key_hash: ConversationAffinity.from_options(opts),
       owner_instance_id: Map.get(opts, :owner_instance_id),
       bridge_owner_lease_ttl_seconds:
         Normalization.optional_positive_integer(Map.get(opts, :bridge_owner_lease_ttl_seconds)),

--- a/lib/codex_pooler/gateway/payloads/request_options/conversation_affinity.ex
+++ b/lib/codex_pooler/gateway/payloads/request_options/conversation_affinity.ex
@@ -1,0 +1,58 @@
+defmodule CodexPooler.Gateway.Payloads.RequestOptions.ConversationAffinity do
+  @moduledoc false
+
+  # Window ids and turn state belong to the short transport lifecycle. Capture
+  # conversation identity separately, even when one of those headers wins attach.
+  # Codex session-id is shared by root and child threads; it is not a conversation.
+  @headers ~w(thread-id x-codex-conversation-id)
+
+  @spec from_headers([{String.t(), String.t()}]) :: binary() | nil
+  def from_headers(headers) when is_list(headers) do
+    headers =
+      for {name, value} <- headers, is_binary(name) and is_binary(value), do: {name, value}
+
+    case Enum.find(@headers, &header_present?(headers, &1)) do
+      nil ->
+        nil
+
+      name ->
+        unique_header_hash(headers, name)
+    end
+  end
+
+  def from_headers(_headers), do: nil
+
+  @spec from_options(map()) :: binary() | nil
+  def from_options(opts) do
+    case Map.fetch(opts, :durable_conversation_key_hash) do
+      {:ok, digest} when is_binary(digest) and byte_size(digest) == 32 ->
+        digest
+
+      {:ok, _invalid_or_absent} ->
+        nil
+
+      :error ->
+        hash("conversation_key", Map.get(opts, :conversation_key)) ||
+          from_headers(Map.get(opts, :forwarded_headers, [])) ||
+          from_headers([{Map.get(opts, :session_header_source), Map.get(opts, :session_header)}])
+    end
+  end
+
+  defp header_present?(headers, name), do: Enum.any?(headers, fn {key, _} -> key == name end)
+
+  defp unique_header_hash(headers, name) do
+    case Enum.filter(headers, fn {key, _value} -> key == name end) do
+      [{^name, value}] -> hash(name, value)
+      _ambiguous -> nil
+    end
+  end
+
+  defp hash(kind, value) when is_binary(value) and byte_size(value) <= 1024 do
+    case String.trim(value) do
+      "" -> nil
+      value -> :crypto.hash(:sha256, :erlang.term_to_binary({kind, value}))
+    end
+  end
+
+  defp hash(_kind, _value), do: nil
+end

--- a/lib/codex_pooler/gateway/persistence/bridge_affinity.ex
+++ b/lib/codex_pooler/gateway/persistence/bridge_affinity.ex
@@ -13,6 +13,8 @@ defmodule CodexPooler.Gateway.Persistence.BridgeAffinity do
     field :affinity_key_hash, :binary
     field :pool_upstream_assignment_id, :binary_id
     field :upstream_identity_id, :binary_id
+    field :generation, :integer, default: 0
+    field :expires_at, :utc_datetime_usec
     field :status, :string
     field :last_hit_at, :utc_datetime_usec
     field :last_miss_at, :utc_datetime_usec

--- a/lib/codex_pooler/gateway/persistence/conversation_affinity.ex
+++ b/lib/codex_pooler/gateway/persistence/conversation_affinity.ex
@@ -1,0 +1,143 @@
+defmodule CodexPooler.Gateway.Persistence.ConversationAffinity do
+  @moduledoc """
+  Bounded, advisory conversation routing. The row id and generation captured by
+  a route plan fence later completion against failover and expiry/recreation.
+  Call reserve/succeed under the canonical assignment reference locks.
+  """
+
+  import Ecto.Query
+
+  alias CodexPooler.Gateway.Persistence.BridgeAffinity
+  alias CodexPooler.Repo
+
+  @kind "durable_conversation"
+  @conflict_target {:unsafe_fragment,
+                    "(pool_id, api_key_id, model_identifier, affinity_kind, affinity_key_hash) WHERE status = 'active'"}
+
+  def kind, do: @kind
+
+  def lookup(scope, now) do
+    scope_query(scope)
+    |> where([affinity], affinity.expires_at > ^now)
+    |> Repo.one()
+  end
+
+  def reserve(scope, assignment, identity, now) do
+    require_transaction!()
+
+    scope_query(scope)
+    |> where([affinity], affinity.expires_at <= ^now)
+    |> Repo.delete_all()
+
+    %BridgeAffinity{
+      pool_id: scope.pool_id,
+      api_key_id: scope.api_key_id,
+      model_identifier: scope.model_identifier,
+      affinity_kind: @kind,
+      affinity_key_hash: scope.key_hash,
+      pool_upstream_assignment_id: assignment.id,
+      upstream_identity_id: identity.id,
+      status: "active",
+      generation: 0,
+      expires_at: DateTime.add(now, scope.idle_seconds, :second),
+      metadata: %{"source" => "gateway_route_plan"},
+      created_at: now,
+      updated_at: now
+    }
+    |> Repo.insert!(on_conflict: :nothing, conflict_target: @conflict_target)
+
+    lookup(scope, now)
+  end
+
+  def succeed(%{row: %BridgeAffinity{} = observed} = scope, assignment, identity) do
+    require_transaction!()
+
+    # Check time only after the row lock is acquired: a writer may have waited
+    # behind another transaction longer than the remaining idle retention.
+    case witnessed_query(observed) |> lock("FOR UPDATE") |> Repo.one() do
+      %BridgeAffinity{} -> write_success(scope, assignment, identity, DateTime.utc_now())
+      nil -> :ok
+    end
+  end
+
+  def succeed(_scope, _assignment, _identity), do: :ok
+
+  defp write_success(%{row: observed} = scope, assignment, identity, now) do
+    # Same-account completions can renew without invalidating concurrent turns.
+    # Only a successful account change advances the generation. A stale writer
+    # cannot overwrite even if its wall-clock completion is the latest one.
+    generation =
+      observed.generation +
+        if(observed.pool_upstream_assignment_id == assignment.id, do: 0, else: 1)
+
+    expires_at = DateTime.add(now, scope.idle_seconds, :second)
+
+    from(affinity in witnessed_query(observed),
+      where: affinity.expires_at > ^now,
+      update: [
+        set: [
+          pool_upstream_assignment_id: ^assignment.id,
+          upstream_identity_id: ^identity.id,
+          generation: ^generation,
+          last_hit_at: fragment("GREATEST(?, ?)", affinity.last_hit_at, ^now),
+          expires_at: fragment("GREATEST(?, ?)", affinity.expires_at, ^expires_at),
+          metadata: ^%{"source" => "gateway_success"},
+          updated_at: fragment("GREATEST(?, ?)", affinity.updated_at, ^now)
+        ]
+      ]
+    )
+    |> Repo.update_all([])
+
+    :ok
+  end
+
+  def miss(%{row: %BridgeAffinity{} = observed}, now) do
+    witnessed_query(observed)
+    |> Repo.update_all(set: [last_miss_at: now])
+
+    :ok
+  end
+
+  def miss(_scope, _now), do: :ok
+
+  @doc "Deletes at most one indexed batch; failed attempts never renew retention."
+  def cleanup(now, batch_size \\ 1000) do
+    expired =
+      from affinity in BridgeAffinity,
+        where:
+          affinity.affinity_kind == ^@kind and affinity.status == "active" and
+            affinity.expires_at <= ^now,
+        order_by: [asc: affinity.expires_at, asc: affinity.id],
+        limit: ^batch_size,
+        lock: "FOR UPDATE SKIP LOCKED",
+        select: affinity.id
+
+    {count, _} =
+      BridgeAffinity
+      |> where([affinity], affinity.id in subquery(expired))
+      |> Repo.delete_all()
+
+    count
+  end
+
+  defp require_transaction! do
+    unless Repo.in_transaction?(),
+      do: raise(ArgumentError, "conversation affinity requires reference-locked transaction")
+  end
+
+  defp witnessed_query(observed) do
+    from affinity in BridgeAffinity,
+      where:
+        affinity.id == ^observed.id and affinity.generation == ^observed.generation and
+          affinity.status == "active"
+  end
+
+  defp scope_query(scope) do
+    from affinity in BridgeAffinity,
+      where:
+        affinity.pool_id == ^scope.pool_id and affinity.api_key_id == ^scope.api_key_id and
+          affinity.model_identifier == ^scope.model_identifier and
+          affinity.affinity_kind == ^@kind and
+          affinity.affinity_key_hash == ^scope.key_hash and affinity.status == "active"
+  end
+end

--- a/lib/codex_pooler/gateway/persistence/runtime_cleanup.ex
+++ b/lib/codex_pooler/gateway/persistence/runtime_cleanup.ex
@@ -13,6 +13,7 @@ defmodule CodexPooler.Gateway.Persistence.RuntimeCleanup do
     BridgeSessionAlias,
     CodexSession,
     CodexTurn,
+    ConversationAffinity,
     IdempotencyKey
   }
 
@@ -119,6 +120,7 @@ defmodule CodexPooler.Gateway.Persistence.RuntimeCleanup do
         |> Repo.update_all(set: [status: expired_idempotency_status, updated_at: now])
 
       %{
+        expired_conversation_affinities: ConversationAffinity.cleanup(now),
         expired_aliases: expired_aliases,
         expired_owner_leases: expired_leases,
         expired_idempotency_keys: expired_idempotency_keys

--- a/lib/codex_pooler/gateway/routing/bridge_ring.ex
+++ b/lib/codex_pooler/gateway/routing/bridge_ring.ex
@@ -21,6 +21,7 @@ defmodule CodexPooler.Gateway.Routing.BridgeRing do
     BridgeAffinity,
     BridgeDemotion,
     CodexSession,
+    ConversationAffinity,
     RoutingCircuitState
   }
 
@@ -120,8 +121,12 @@ defmodule CodexPooler.Gateway.Routing.BridgeRing do
       |> apply_prompt_cache_locality(prompt_cache_locality)
       |> apply_affinity(affinity)
       |> apply_codex_session_preference(request_options)
+      |> apply_durable_affinity(affinity)
       |> apply_demotions(demotions)
       |> apply_windowless_tier(model, route_state)
+
+    {ordered, affinity} =
+      reserve_durable_route(ordered, affinity, demotions, model, route_state)
 
     ring_size = max(settings.bridge_ring_size || @default_ring_size, 1)
     candidates = Enum.take(ordered, ring_size)
@@ -203,8 +208,8 @@ defmodule CodexPooler.Gateway.Routing.BridgeRing do
       fun.()
     end)
     |> case do
-      {:ok, _result} ->
-        :ok
+      {:ok, result} ->
+        result
 
       {:error, reason} ->
         log_skipped_side_effect(side_effect, assignment, identity, skip_code(reason))
@@ -327,8 +332,13 @@ defmodule CodexPooler.Gateway.Routing.BridgeRing do
       idempotency_key: idempotency_key
     } = affinity_request_context(opts)
 
+    stable_key = opts.continuity.durable_conversation_key_hash
+
     {enabled?, kind, key_value} =
       cond do
+        settings.durable_conversation_affinity_enabled and is_binary(stable_key) ->
+          {true, ConversationAffinity.kind(), stable_key}
+
         codex_session && settings.sticky_websocket_sessions ->
           {true, "codex_session", codex_session.id}
 
@@ -352,7 +362,12 @@ defmodule CodexPooler.Gateway.Routing.BridgeRing do
       enabled?: enabled?,
       kind: kind,
       key_hash: key_hash,
-      seed: key_value || input.correlation_id,
+      seed:
+        if(kind == ConversationAffinity.kind(),
+          do: Base.encode16(key_hash),
+          else: key_value || input.correlation_id
+        ),
+      idle_seconds: settings.durable_conversation_affinity_idle_seconds,
       row: affinity,
       status: affinity_status(enabled?, affinity),
       fallback_reason: nil,
@@ -370,12 +385,33 @@ defmodule CodexPooler.Gateway.Routing.BridgeRing do
     }
   end
 
+  defp affinity_hash(auth, model, "durable_conversation", key_value) do
+    :crypto.hash(
+      :sha256,
+      :erlang.term_to_binary(
+        {auth.pool.id, auth.api_key.id, model.exposed_model_id, "durable_conversation", key_value}
+      )
+    )
+  end
+
   defp affinity_hash(auth, model, kind, key_value) do
     canonical_key =
       [auth.pool.id, auth.api_key.id, model.exposed_model_id, kind, key_value]
       |> Enum.join(":")
 
     :crypto.hash(:sha256, canonical_key)
+  end
+
+  defp active_affinity(auth, model, "durable_conversation", key_hash) do
+    ConversationAffinity.lookup(
+      %{
+        pool_id: auth.pool.id,
+        api_key_id: auth.api_key.id,
+        model_identifier: model.exposed_model_id,
+        key_hash: key_hash
+      },
+      now()
+    )
   end
 
   defp active_affinity(auth, model, kind, key_hash) do
@@ -393,6 +429,13 @@ defmodule CodexPooler.Gateway.Routing.BridgeRing do
   end
 
   defp affinity_status(false, _affinity), do: "disabled"
+
+  defp affinity_status(true, %BridgeAffinity{
+         affinity_kind: "durable_conversation",
+         last_hit_at: nil
+       }),
+       do: "reserved"
+
   defp affinity_status(true, %BridgeAffinity{}), do: "hit"
   defp affinity_status(true, _affinity), do: "miss"
 
@@ -406,6 +449,40 @@ defmodule CodexPooler.Gateway.Routing.BridgeRing do
 
     matched ++ rest
   end
+
+  defp apply_durable_affinity(candidates, %{kind: "durable_conversation"} = affinity),
+    do: apply_affinity(candidates, affinity)
+
+  defp apply_durable_affinity(candidates, _affinity), do: candidates
+
+  defp reserve_durable_route(
+         [{assignment, identity} | _] = ordered,
+         %{kind: "durable_conversation", row: nil} = affinity,
+         demotions,
+         model,
+         route_state
+       ) do
+    case locked_side_effect(:affinity_reserve, assignment, identity, fn ->
+           ConversationAffinity.reserve(affinity, assignment, identity, now())
+         end) do
+      %BridgeAffinity{} = row ->
+        affinity = %{affinity | row: row, status: affinity_status(true, row)}
+
+        ordered =
+          ordered
+          |> apply_durable_affinity(affinity)
+          |> apply_demotions(demotions)
+          |> apply_windowless_tier(model, route_state)
+
+        {ordered, affinity}
+
+      _skipped ->
+        {ordered, affinity}
+    end
+  end
+
+  defp reserve_durable_route(ordered, affinity, _demotions, _model, _route_state),
+    do: {ordered, affinity}
 
   defp apply_codex_session_preference(
          candidates,
@@ -593,6 +670,14 @@ defmodule CodexPooler.Gateway.Routing.BridgeRing do
 
   defp apply_windowless_tier(candidates, %Model{}, nil), do: candidates
 
+  defp upsert_affinity!(
+         %{affinity: %{kind: "durable_conversation"} = affinity},
+         assignment,
+         identity,
+         _now
+       ),
+       do: ConversationAffinity.succeed(affinity, assignment, identity)
+
   defp upsert_affinity!(plan, assignment, identity, now) do
     metadata = %{"source" => "gateway_success"}
 
@@ -632,6 +717,9 @@ defmodule CodexPooler.Gateway.Routing.BridgeRing do
       conflict_target: @affinity_conflict_target
     )
   end
+
+  defp mark_affinity_miss!(%{affinity: %{kind: "durable_conversation"} = affinity}, now),
+    do: ConversationAffinity.miss(affinity, now)
 
   defp mark_affinity_miss!(plan, now) do
     case plan.affinity.row do

--- a/lib/codex_pooler/gateway/routing/bridge_ring/status.ex
+++ b/lib/codex_pooler/gateway/routing/bridge_ring/status.ex
@@ -25,10 +25,13 @@ defmodule CodexPooler.Gateway.Routing.BridgeRing.Status do
       RoutingCircuitState.half_open_status()
     ]
 
+    now = DateTime.utc_now()
+
     active_affinity_count =
       Repo.aggregate(
         from(affinity in BridgeAffinity,
-          where: affinity.pool_id == ^pool_id and affinity.status == ^active_affinity_status
+          where: affinity.pool_id == ^pool_id and affinity.status == ^active_affinity_status,
+          where: is_nil(affinity.expires_at) or affinity.expires_at > ^now
         ),
         :count,
         :id

--- a/lib/codex_pooler/pools/routing.ex
+++ b/lib/codex_pooler/pools/routing.ex
@@ -123,6 +123,22 @@ defmodule CodexPooler.Pools.Routing do
           parse_boolean(
             routing_attr(attrs, "sticky_http_sessions", settings.sticky_http_sessions)
           ),
+        durable_conversation_affinity_enabled:
+          parse_boolean(
+            routing_attr(
+              attrs,
+              "durable_conversation_affinity_enabled",
+              settings.durable_conversation_affinity_enabled
+            )
+          ),
+        durable_conversation_affinity_idle_seconds:
+          parse_positive_integer(
+            routing_attr(
+              attrs,
+              "durable_conversation_affinity_idle_seconds",
+              settings.durable_conversation_affinity_idle_seconds
+            )
+          ),
         prompt_cache_affinity_enabled:
           parse_boolean(
             routing_attr(
@@ -167,6 +183,9 @@ defmodule CodexPooler.Pools.Routing do
             bridge_ring_size: settings.bridge_ring_size,
             sticky_websocket_sessions: settings.sticky_websocket_sessions,
             sticky_http_sessions: settings.sticky_http_sessions,
+            durable_conversation_affinity_enabled: settings.durable_conversation_affinity_enabled,
+            durable_conversation_affinity_idle_seconds:
+              settings.durable_conversation_affinity_idle_seconds,
             prompt_cache_affinity_enabled: settings.prompt_cache_affinity_enabled,
             request_compression_enabled: settings.request_compression_enabled,
             allow_image_generation: settings.allow_image_generation
@@ -204,6 +223,8 @@ defmodule CodexPooler.Pools.Routing do
       bridge_ring_size: 3,
       sticky_websocket_sessions: true,
       sticky_http_sessions: false,
+      durable_conversation_affinity_enabled: false,
+      durable_conversation_affinity_idle_seconds: 86_400,
       prompt_cache_affinity_enabled: true,
       v1_compatibility_enabled: true,
       request_compression_enabled: false,

--- a/lib/codex_pooler/pools/routing_settings.ex
+++ b/lib/codex_pooler/pools/routing_settings.ex
@@ -16,6 +16,8 @@ defmodule CodexPooler.Pools.RoutingSettings do
     field :bridge_ring_size, :integer
     field :sticky_websocket_sessions, :boolean
     field :sticky_http_sessions, :boolean
+    field :durable_conversation_affinity_enabled, :boolean, default: false
+    field :durable_conversation_affinity_idle_seconds, :integer, default: 86_400
     field :prompt_cache_affinity_enabled, :boolean, default: true
     field :v1_compatibility_enabled, :boolean, default: true
     field :request_compression_enabled, :boolean, default: false
@@ -34,6 +36,8 @@ defmodule CodexPooler.Pools.RoutingSettings do
       :bridge_ring_size,
       :sticky_websocket_sessions,
       :sticky_http_sessions,
+      :durable_conversation_affinity_enabled,
+      :durable_conversation_affinity_idle_seconds,
       :prompt_cache_affinity_enabled,
       :v1_compatibility_enabled,
       :request_compression_enabled,
@@ -48,6 +52,8 @@ defmodule CodexPooler.Pools.RoutingSettings do
       :bridge_ring_size,
       :sticky_websocket_sessions,
       :sticky_http_sessions,
+      :durable_conversation_affinity_enabled,
+      :durable_conversation_affinity_idle_seconds,
       :prompt_cache_affinity_enabled,
       :v1_compatibility_enabled,
       :request_compression_enabled,
@@ -58,6 +64,10 @@ defmodule CodexPooler.Pools.RoutingSettings do
     ])
     |> validate_inclusion(:routing_strategy, @routing_strategies)
     |> validate_number(:bridge_ring_size, greater_than_or_equal_to: 1)
+    |> validate_number(:durable_conversation_affinity_idle_seconds,
+      greater_than_or_equal_to: 60,
+      less_than_or_equal_to: 2_592_000
+    )
   end
 
   @spec routing_strategies() :: [String.t()]

--- a/lib/codex_pooler_web/controllers/gateway_controller_helpers.ex
+++ b/lib/codex_pooler_web/controllers/gateway_controller_helpers.ex
@@ -13,6 +13,7 @@ defmodule CodexPoolerWeb.GatewayControllerHelpers do
   alias CodexPooler.Gateway.Metadata
   alias CodexPooler.Gateway.OperationalSettings
   alias CodexPooler.Gateway.Payloads.RequestOptions
+  alias CodexPooler.Gateway.Payloads.RequestOptions.ConversationAffinity
   alias CodexPooler.Pools.Routing, as: PoolRouting
 
   @overload_code "server_is_overloaded"
@@ -140,6 +141,7 @@ defmodule CodexPoolerWeb.GatewayControllerHelpers do
       previous_response_id: previous_response_id(conn),
       session_header: session_header,
       session_header_source: session_header_source,
+      durable_conversation_key_hash: ConversationAffinity.from_headers(conn.req_headers),
       user_agent: get_req_header(conn, "user-agent") |> List.first(),
       request_content_type: get_req_header(conn, "content-type") |> List.first(),
       forwarded_headers: forwarded_headers(conn),

--- a/lib/codex_pooler_web/live/admin/components/pages/pools/wizard_components.ex
+++ b/lib/codex_pooler_web/live/admin/components/pages/pools/wizard_components.ex
@@ -293,6 +293,20 @@ defmodule CodexPoolerWeb.Admin.PoolWizardComponents do
                         help="Same upstream preference for related HTTP requests."
                       />
                       <.routing_toggle_row
+                        field={@form[:durable_conversation_affinity_enabled]}
+                        label="Durable conversation affinity"
+                        help="Remember an eligible account across reconnects; keep successful failover choices."
+                      />
+                      <div class="p-3">
+                        <.input
+                          field={@form[:durable_conversation_affinity_idle_seconds]}
+                          type="number"
+                          label="Conversation affinity idle retention (seconds)"
+                          min="60"
+                          max="2592000"
+                        />
+                      </div>
+                      <.routing_toggle_row
                         field={@form[:prompt_cache_affinity_enabled]}
                         label="Prompt cache affinity"
                         help="Sends requests that share a prompt cache to the same upstream."

--- a/lib/codex_pooler_web/live/admin/forms/pool_form.ex
+++ b/lib/codex_pooler_web/live/admin/forms/pool_form.ex
@@ -160,6 +160,9 @@ defmodule CodexPoolerWeb.Admin.PoolForm do
       "bridge_ring_size" => settings.bridge_ring_size,
       "sticky_websocket_sessions" => settings.sticky_websocket_sessions,
       "sticky_http_sessions" => settings.sticky_http_sessions,
+      "durable_conversation_affinity_enabled" => settings.durable_conversation_affinity_enabled,
+      "durable_conversation_affinity_idle_seconds" =>
+        settings.durable_conversation_affinity_idle_seconds,
       "prompt_cache_affinity_enabled" => settings.prompt_cache_affinity_enabled,
       "v1_compatibility_enabled" => settings.v1_compatibility_enabled,
       "request_compression_enabled" => settings.request_compression_enabled,
@@ -303,6 +306,8 @@ defmodule CodexPoolerWeb.Admin.PoolForm do
       "bridge_ring_size" => 3,
       "sticky_websocket_sessions" => true,
       "sticky_http_sessions" => false,
+      "durable_conversation_affinity_enabled" => false,
+      "durable_conversation_affinity_idle_seconds" => 86_400,
       "prompt_cache_affinity_enabled" => true,
       "v1_compatibility_enabled" => true,
       "request_compression_enabled" => false,

--- a/priv/repo/migrations/20260908090000_add_durable_conversation_affinity.exs
+++ b/priv/repo/migrations/20260908090000_add_durable_conversation_affinity.exs
@@ -1,0 +1,44 @@
+defmodule CodexPooler.Repo.Migrations.AddDurableConversationAffinity do
+  use Ecto.Migration
+
+  def up do
+    alter table(:pool_routing_settings, primary_key: false) do
+      add :durable_conversation_affinity_enabled, :boolean, null: false, default: false
+      add :durable_conversation_affinity_idle_seconds, :integer, null: false, default: 86_400
+    end
+
+    create constraint(:pool_routing_settings, :durable_conversation_affinity_idle_bounds,
+             check: "durable_conversation_affinity_idle_seconds BETWEEN 60 AND 2592000"
+           )
+
+    alter table(:bridge_affinities) do
+      add :generation, :bigint, null: false, default: 0
+      add :expires_at, :utc_datetime_usec
+    end
+
+    create index(:bridge_affinities, [:expires_at, :id],
+             name: :bridge_affinities_durable_expiry_idx,
+             where: "affinity_kind = 'durable_conversation' AND status = 'active'"
+           )
+  end
+
+  def down do
+    execute "DELETE FROM bridge_affinities WHERE affinity_kind = 'durable_conversation'"
+
+    drop index(:bridge_affinities, [:expires_at, :id],
+           name: :bridge_affinities_durable_expiry_idx
+         )
+
+    alter table(:bridge_affinities) do
+      remove :generation
+      remove :expires_at
+    end
+
+    drop constraint(:pool_routing_settings, :durable_conversation_affinity_idle_bounds)
+
+    alter table(:pool_routing_settings, primary_key: false) do
+      remove :durable_conversation_affinity_enabled
+      remove :durable_conversation_affinity_idle_seconds
+    end
+  end
+end

--- a/test/codex_pooler/admin/pool_workflow_test.exs
+++ b/test/codex_pooler/admin/pool_workflow_test.exs
@@ -270,6 +270,36 @@ defmodule CodexPooler.Admin.PoolWorkflowTest do
   end
 
   describe "pool routing settings workflow" do
+    test "durable affinity settings persist through create, edit and form reload" do
+      %{user: owner} = bootstrap_owner_fixture(%{"email" => "affinity-owner@example.com"})
+      scope = Scope.for_user(owner, ["instance_owner"])
+
+      assert {:ok, pool} =
+               PoolWorkflow.create_pool_with_related_settings(scope, %{
+                 "name" => "Durable affinity workflow",
+                 "durable_conversation_affinity_enabled" => "true",
+                 "durable_conversation_affinity_idle_seconds" => "3600"
+               })
+
+      assert %{
+               durable_conversation_affinity_enabled: true,
+               durable_conversation_affinity_idle_seconds: 3600
+             } = Pools.get_routing_settings(pool)
+
+      assert {:ok, pool} =
+               PoolWorkflow.update_pool_with_related_settings(scope, pool, %{
+                 "name" => pool.name,
+                 "status" => "active",
+                 "durable_conversation_affinity_enabled" => "false",
+                 "durable_conversation_affinity_idle_seconds" => "7200"
+               })
+
+      assert %{
+               durable_conversation_affinity_enabled: false,
+               durable_conversation_affinity_idle_seconds: 7200
+             } = Pools.get_routing_settings(pool)
+    end
+
     test "creation persists request compression routing setting when enabled" do
       %{user: owner} = bootstrap_owner_fixture(%{"email" => "owner@example.com"})
       scope = Scope.for_user(owner, ["instance_owner"])

--- a/test/codex_pooler/gateway/persistence/conversation_affinity_locking_test.exs
+++ b/test/codex_pooler/gateway/persistence/conversation_affinity_locking_test.exs
@@ -1,0 +1,224 @@
+defmodule CodexPooler.Gateway.Persistence.ConversationAffinityLockingTest do
+  use CodexPooler.DataCase, async: false
+
+  import CodexPooler.PoolerFixtures
+  import CodexPooler.AccountsFixtures, only: [reset_bootstrap_state_fixture!: 0]
+
+  alias CodexPooler.Gateway.Payloads.RequestOptions
+  alias CodexPooler.Gateway.Persistence.BridgeAffinity
+  alias CodexPooler.Gateway.Routing.{BridgeRing, RoutePlanInput}
+  alias CodexPooler.Pools
+  alias Ecto.Adapters.SQL.Sandbox
+
+  test "independent transactions share first reservation and fence a late old-account writer" do
+    context = committed_context()
+
+    parent = self()
+
+    first =
+      actor(fn ->
+        Repo.transaction(fn ->
+          plan = route(context)
+          send(parent, {:first_reserved, plan, backend()})
+
+          receive do
+            :commit_first -> plan
+          after
+            10_000 -> flunk("first reservation not released")
+          end
+        end)
+      end)
+
+    assert_receive {:first_reserved, first_plan, first_backend}, 5000
+
+    contender =
+      actor(fn ->
+        send(parent, {:contender_backend, backend()})
+        route(%{context | candidates: Enum.reverse(context.candidates)})
+      end)
+
+    try do
+      assert_receive {:contender_backend, second_backend}, 5000
+      refute first_backend == second_backend
+      await_blocked(second_backend, 200)
+      send(first.pid, :commit_first)
+      assert {:ok, ^first_plan} = Task.await(first)
+      second_plan = Task.await(contender)
+      assert second_plan.affinity.row.id == first_plan.affinity.row.id
+      assert second_plan.selected_assignment_id == first_plan.selected_assignment_id
+      assert second_plan.affinity.status == "reserved"
+      refute second_plan.request_metadata["affinity_hit"]
+      [a, b] = first_plan.candidates
+
+      failover =
+        actor(fn ->
+          Repo.transaction(fn ->
+            BridgeRing.record_success(second_plan, elem(b, 0), elem(b, 1))
+            send(parent, :failover_written)
+
+            receive do
+              :commit_failover -> :ok
+            after
+              10_000 -> flunk("failover not released")
+            end
+          end)
+        end)
+
+      assert_receive :failover_written, 5000
+
+      late =
+        actor(fn ->
+          send(parent, {:late_backend, backend()})
+          BridgeRing.record_success(first_plan, elem(a, 0), elem(a, 1))
+        end)
+
+      try do
+        assert_receive {:late_backend, late_backend}, 5000
+        await_blocked(late_backend, 200)
+        send(failover.pid, :commit_failover)
+        assert {:ok, :ok} = Task.await(failover)
+        assert :ok = Task.await(late)
+
+        unboxed(fn ->
+          row = Repo.get!(BridgeAffinity, first_plan.affinity.row.id)
+          assert row.generation == 1
+          assert row.pool_upstream_assignment_id == elem(b, 0).id
+        end)
+
+        after_restart = actor(fn -> route(context) end) |> Task.await()
+        assert after_restart.selected_assignment_id == elem(b, 0).id
+      after
+        send(failover.pid, :commit_failover)
+        Task.shutdown(failover, :brutal_kill)
+        Task.shutdown(late, :brutal_kill)
+      end
+    after
+      send(first.pid, :commit_first)
+      Task.shutdown(first, :brutal_kill)
+      Task.shutdown(contender, :brutal_kill)
+      unboxed(fn -> reset_bootstrap_state_fixture!() end)
+    end
+  end
+
+  test "completion waiting on affinity row cannot revive it after idle expiry" do
+    context = committed_context()
+    plan = unboxed(fn -> route(context) end)
+    expires_at = DateTime.add(DateTime.utc_now(), 500, :millisecond)
+
+    unboxed(fn ->
+      Repo.update!(Ecto.Changeset.change(plan.affinity.row, expires_at: expires_at))
+    end)
+
+    parent = self()
+
+    blocker =
+      actor(fn ->
+        Repo.transaction(fn ->
+          Repo.one!(
+            from a in BridgeAffinity, where: a.id == ^plan.affinity.row.id, lock: "FOR UPDATE"
+          )
+
+          send(parent, :affinity_locked)
+
+          receive do
+            :unlock -> :ok
+          after
+            10_000 -> flunk("expiry lock not released")
+          end
+        end)
+      end)
+
+    assert_receive :affinity_locked, 5000
+
+    completion =
+      actor(fn ->
+        send(parent, {:completion_backend, backend()})
+        {assignment, identity} = hd(plan.candidates)
+        BridgeRing.record_success(plan, assignment, identity)
+      end)
+
+    try do
+      assert_receive {:completion_backend, backend}, 5000
+      await_blocked(backend, 200)
+      Process.sleep(max(DateTime.diff(expires_at, DateTime.utc_now(), :millisecond), 0) + 50)
+      send(blocker.pid, :unlock)
+      assert {:ok, :ok} = Task.await(blocker)
+      assert :ok = Task.await(completion)
+
+      unboxed(fn ->
+        row = Repo.get!(BridgeAffinity, plan.affinity.row.id)
+        assert row.expires_at == expires_at
+        assert row.last_hit_at == nil
+      end)
+    after
+      send(blocker.pid, :unlock)
+      Task.shutdown(blocker, :brutal_kill)
+      Task.shutdown(completion, :brutal_kill)
+      unboxed(fn -> reset_bootstrap_state_fixture!() end)
+    end
+  end
+
+  defp committed_context do
+    unboxed(fn ->
+      reset_bootstrap_state_fixture!()
+      key = active_api_key_fixture()
+
+      candidates =
+        for _ <- 1..2 do
+          %{assignment: assignment, identity: identity} =
+            active_upstream_assignment_fixture(key.pool)
+
+          {assignment, identity}
+        end
+
+      model = model_fixture(key.pool)
+
+      Pools.ensure_routing_settings(key.pool)
+      |> Ecto.Changeset.change(durable_conversation_affinity_enabled: true)
+      |> Repo.update!()
+
+      %{auth: %{pool: key.pool, api_key: key.api_key}, model: model, candidates: candidates}
+    end)
+  end
+
+  defp route(context) do
+    opts =
+      RequestOptions.build(
+        %{conversation_key: "synthetic-shared-thread"},
+        "/backend-api/codex/responses",
+        %{}
+      )
+
+    BridgeRing.plan_route(
+      Map.merge(context, %{
+        request_options: opts,
+        route_plan_input: %RoutePlanInput{correlation_id: Ecto.UUID.generate()}
+      })
+    )
+  end
+
+  defp actor(fun), do: Task.async(fn -> unboxed(fun) end)
+  defp unboxed(fun), do: Sandbox.unboxed_run(Repo, fun)
+
+  defp backend do
+    %{rows: [[pid]]} = Repo.query!("SELECT pg_backend_pid()")
+    pid
+  end
+
+  defp await_blocked(_backend, 0), do: flunk("competing transaction never waited on its row lock")
+
+  defp await_blocked(backend, retries) do
+    blocked =
+      unboxed(fn ->
+        %{rows: [[blocked]]} =
+          Repo.query!("SELECT cardinality(pg_blocking_pids($1)) > 0", [backend])
+
+        blocked
+      end)
+
+    unless blocked do
+      Process.sleep(10)
+      await_blocked(backend, retries - 1)
+    end
+  end
+end

--- a/test/codex_pooler/gateway/routing/durable_conversation_affinity_test.exs
+++ b/test/codex_pooler/gateway/routing/durable_conversation_affinity_test.exs
@@ -1,0 +1,383 @@
+defmodule CodexPooler.Gateway.Routing.DurableConversationAffinityTest do
+  use CodexPooler.DataCase, async: false
+
+  import CodexPooler.PoolerFixtures
+
+  alias CodexPooler.Gateway.Payloads.RequestOptions
+
+  alias CodexPooler.Gateway.Persistence.{
+    BridgeAffinity,
+    BridgeDemotion,
+    CodexSession,
+    ConversationAffinity,
+    RuntimeCleanup,
+    SessionContinuity
+  }
+
+  alias CodexPooler.Gateway.Routing.{BridgeRing, RoutePlanInput}
+  alias CodexPooler.Gateway.Routing.SessionContinuity, as: RoutingContinuity
+  alias CodexPooler.Pools
+  alias CodexPooler.Pools.RoutingSettings
+  alias CodexPoolerWeb.GatewayControllerHelpers
+
+  setup do
+    pool = pool_fixture()
+    auth = active_api_key_fixture(pool)
+
+    candidates =
+      for _ <- 1..3 do
+        %{assignment: assignment, identity: identity} = active_upstream_assignment_fixture(pool)
+        {assignment, identity}
+      end
+
+    model =
+      model_fixture(pool, %{
+        metadata: %{"source_assignment_ids" => Enum.map(candidates, &elem(&1, 0).id)}
+      })
+
+    settings =
+      pool
+      |> Pools.ensure_routing_settings()
+      |> Ecto.Changeset.change(durable_conversation_affinity_enabled: true)
+      |> Repo.update!()
+
+    %{
+      pool: pool,
+      auth: %{pool: pool, api_key: auth.api_key},
+      model: model,
+      candidates: candidates,
+      settings: settings
+    }
+  end
+
+  test "off by default and idle retention is bounded", context do
+    assert %RoutingSettings{
+             durable_conversation_affinity_enabled: false,
+             durable_conversation_affinity_idle_seconds: 86_400
+           } = Pools.routing_settings_with_defaults(Ecto.UUID.generate())
+
+    for invalid <- [0, 59, 2_592_001] do
+      refute RoutingSettings.changeset(context.settings, %{
+               durable_conversation_affinity_idle_seconds: invalid
+             }).valid?
+    end
+
+    Repo.update!(
+      Ecto.Changeset.change(context.settings, durable_conversation_affinity_enabled: false)
+    )
+
+    refute plan(context, options()).affinity.kind == "durable_conversation"
+    assert Repo.aggregate(durable_rows(), :count) == 0
+  end
+
+  test "HTTP ingress captures typed stable identity separately from rotating window and turn state",
+       context do
+    first = ingress_options("window-a", "turn-a", "conversation")
+    second = ingress_options("window-b", "turn-b", "conversation")
+    assert first.continuity.session_header == "window-a"
+    assert second.continuity.session_header == "window-b"
+
+    assert first.continuity.durable_conversation_key_hash ==
+             second.continuity.durable_conversation_key_hash
+
+    assert plan(context, first).affinity.key_hash == plan(context, second).affinity.key_hash
+  end
+
+  test "thread IDs separate children sharing a root session; invalid selected headers fail closed",
+       context do
+    root = [{"session-id", "shared-root"}, {"x-codex-window-id", "window"}]
+
+    hashes =
+      for thread <- ["child-a", "child-b"] do
+        conn = %{Phoenix.ConnTest.build_conn() | req_headers: [{"thread-id", thread} | root]}
+
+        opts =
+          conn
+          |> GatewayControllerHelpers.request_opts()
+          |> RequestOptions.build("/backend-api/codex/responses", %{})
+
+        plan(context, opts).affinity.key_hash
+      end
+
+    assert length(Enum.uniq(hashes)) == 2
+
+    for invalid <- [
+          [],
+          [{"thread-id", " "}],
+          [{"thread-id", String.duplicate("x", 1025)}],
+          [{"thread-id", "a"}, {"thread-id", "b"}, {"x-codex-conversation-id", "fallback"}]
+        ] do
+      conn = %{Phoenix.ConnTest.build_conn() | req_headers: invalid ++ root}
+
+      opts =
+        conn
+        |> GatewayControllerHelpers.request_opts()
+        |> RequestOptions.build("/backend-api/codex/responses", %{})
+
+      refute plan(context, opts).affinity.kind == "durable_conversation"
+    end
+  end
+
+  test "initial choice is stable without a prior row despite a new request correlation",
+       context do
+    first = plan(context, options())
+    Repo.delete!(first.affinity.row)
+    second = plan(context, options())
+    assert second.selected_assignment_id == first.selected_assignment_id
+    refute second.affinity.row.id == first.affinity.row.id
+  end
+
+  test "older same-account completion cannot shorten stored timestamps or expiry", context do
+    first = plan(context, options())
+    {assignment, identity} = hd(first.candidates)
+    later = DateTime.add(DateTime.utc_now(), 30, :second)
+
+    row =
+      first.affinity.row
+      |> Ecto.Changeset.change(
+        last_hit_at: later,
+        updated_at: later,
+        expires_at: DateTime.add(later, 86_400, :second)
+      )
+      |> Repo.update!()
+
+    BridgeRing.record_success(first, assignment, identity)
+    updated = Repo.get!(BridgeAffinity, row.id)
+
+    assert Map.take(updated, [:last_hit_at, :updated_at, :expires_at]) ==
+             Map.take(row, [:last_hit_at, :updated_at, :expires_at])
+  end
+
+  test "idle transport expiration recreates DB UUID but another process reuses durable account",
+       context do
+    opts = options()
+    {:ok, session_a} = SessionContinuity.start_codex_session(context.auth, opts)
+    first = plan(context, RequestOptions.put_continuity(opts, codex_session: session_a))
+    succeed(first, hd(first.candidates))
+    expired_at = DateTime.add(DateTime.utc_now(), -120, :second)
+    Repo.update!(Ecto.Changeset.change(session_a, owner_lease_expires_at: expired_at))
+    {:ok, session_b} = SessionContinuity.start_codex_session(context.auth, opts)
+    refute session_a.id == session_b.id
+
+    second =
+      Task.async(fn ->
+        plan(context, RequestOptions.put_continuity(opts, codex_session: session_b))
+      end)
+      |> Task.await()
+
+    assert second.selected_assignment_id == first.selected_assignment_id
+    assert second.affinity.row.id == first.affinity.row.id
+    assert second.affinity.status == "hit"
+    assert Repo.aggregate(durable_rows(), :count) == 1
+  end
+
+  test "stable initial routing and unchanged prompt-cache input", context do
+    payload = %{
+      "model" => context.model.exposed_model_id,
+      "prompt_cache_key" => "original-cache-key"
+    }
+
+    opts = options(%{}, payload)
+    normalized_cache_key = opts.routing.prompt_cache_key
+    first = plan(context, opts)
+    second = plan(context, opts)
+    assert first.selected_assignment_id == second.selected_assignment_id
+    assert first.affinity.row.id == second.affinity.row.id
+    assert first.locality.status == "applied"
+    assert opts.routing.prompt_cache_key == normalized_cache_key
+    refute inspect(first.request_metadata) =~ "conversation-fixture"
+    refute inspect(first.affinity.row) =~ "conversation-fixture"
+  end
+
+  test "scope isolates pool, API key, model and typed key", context do
+    first = plan(context, options())
+    other_auth = active_api_key_fixture(context.pool)
+    other_model = model_fixture(context.pool, %{exposed_model_id: "other-affinity-model"})
+    other_pool = pool_fixture()
+    other_pool_auth = active_api_key_fixture(other_pool)
+
+    %{assignment: other_assignment, identity: other_identity} =
+      active_upstream_assignment_fixture(other_pool)
+
+    Pools.ensure_routing_settings(other_pool)
+    |> Ecto.Changeset.change(durable_conversation_affinity_enabled: true)
+    |> Repo.update!()
+
+    variants = [
+      plan(%{context | auth: %{pool: context.pool, api_key: other_auth.api_key}}, options()),
+      plan(%{context | model: other_model}, options()),
+      plan(context, options(%{conversation_key: "conversation-fixture"})),
+      plan(context, options(%{session_header: "other-conversation"})),
+      plan(
+        %{
+          context
+          | pool: other_pool,
+            auth: %{pool: other_pool, api_key: other_pool_auth.api_key},
+            candidates: [{other_assignment, other_identity}]
+        },
+        options()
+      )
+    ]
+
+    hashes = Enum.map([first | variants], & &1.affinity.key_hash)
+    assert length(Enum.uniq(hashes)) == 6
+  end
+
+  test "missing, random session keys, turn-state and window-only inputs create no durable mapping",
+       context do
+    for raw <- [
+          %{},
+          %{session_key: "random-key"},
+          %{accepted_turn_state: "rotating-turn"},
+          %{session_header_source: "x-codex-window-id", session_header: "window-only"},
+          %{session_header_source: "x-codex-conversation-id", session_header: " "}
+        ] do
+      opts = RequestOptions.build(raw, "/backend-api/codex/responses", %{})
+      refute plan(context, opts).affinity.kind == "durable_conversation"
+    end
+
+    assert Repo.aggregate(durable_rows(), :count) == 0
+    assert plan(%{context | candidates: []}, options()).candidates == []
+    assert Repo.aggregate(durable_rows(), :count) == 0
+  end
+
+  for {label, reason} <- [{"429", "upstream_rate_limited"}, {"503", "upstream_5xx"}] do
+    test "successful #{label} failover survives A recovery and late A completion", context do
+      first = plan(context, options())
+      [a, b | _] = first.candidates
+      succeed(first, a)
+      stale_a = plan(context, options())
+      failover = plan(context, options())
+
+      assert BridgeRing.record_failure(failover, elem(a, 0), elem(a, 1), unquote(reason)) ==
+               unquote(reason)
+
+      succeed(failover, b)
+      before_late = Repo.get!(BridgeAffinity, first.affinity.row.id)
+      assert before_late.generation == 1
+      succeed(stale_a, a)
+      assert Repo.get!(BridgeAffinity, before_late.id) == before_late
+
+      Repo.update_all(BridgeDemotion,
+        set: [demoted_until: DateTime.add(DateTime.utc_now(), -1, :second)]
+      )
+
+      old_session = %CodexSession{
+        id: Ecto.UUID.generate(),
+        pool_upstream_assignment_id: elem(a, 0).id
+      }
+
+      recovered =
+        plan(context, RequestOptions.put_continuity(options(), codex_session: old_session))
+
+      assert recovered.selected_assignment_id == elem(b, 0).id
+    end
+  end
+
+  test "eligible quota fallback becomes durable and never restores an excluded account",
+       context do
+    first = plan(context, options())
+    [a, b | _] = first.candidates
+    succeed(first, a)
+    reduced = %{context | candidates: [b]}
+    fallback = plan(reduced, options())
+    assert fallback.candidates == [b]
+    succeed(fallback, b)
+    assert plan(context, options()).selected_assignment_id == elem(b, 0).id
+  end
+
+  test "strict previous response, file and active websocket pins retain precedence", context do
+    first = plan(context, options())
+    [a, b | _] = first.candidates
+    succeed(first, b)
+    session = %CodexSession{id: Ecto.UUID.generate(), pool_upstream_assignment_id: elem(a, 0).id}
+
+    for pin <- [
+          %{previous_response_id: "resp-strict"},
+          %{file_affinity_assignment_id: elem(a, 0).id},
+          %{upstream_websocket_session: self()}
+        ] do
+      opts = options(Map.put(pin, :codex_session, session))
+
+      assert {:ok, pinned} =
+               RoutingContinuity.apply_codex_session_assignment(
+                 context.candidates,
+                 opts,
+                 context.model
+               )
+
+      assert pinned == [a]
+      assert plan(%{context | candidates: pinned}, opts).selected_assignment_id == elem(a, 0).id
+    end
+  end
+
+  test "failures do not renew idle expiry; cleanup is bounded and fences recreated rows",
+       context do
+    first = plan(context, options())
+    [a, b | _] = first.candidates
+    BridgeRing.record_failure(first, elem(a, 0), elem(a, 1), "upstream_rate_limited")
+
+    assert Repo.get!(BridgeAffinity, first.affinity.row.id).expires_at ==
+             first.affinity.row.expires_at
+
+    expired_at = DateTime.add(DateTime.utc_now(), -1, :second)
+    Repo.update!(Ecto.Changeset.change(first.affinity.row, expires_at: expired_at))
+    second = plan(context, options(%{session_header: "second"}))
+    Repo.update!(Ecto.Changeset.change(second.affinity.row, expires_at: expired_at))
+    assert BridgeRing.routing_status(context.pool).active_affinity_count == 0
+    assert ConversationAffinity.cleanup(DateTime.utc_now(), 1) == 1
+    assert {:ok, %{expired_conversation_affinities: 1}} = RuntimeCleanup.cleanup_expired()
+    fresh = plan(context, options())
+    refute fresh.affinity.row.id == first.affinity.row.id
+    succeed(fresh, b)
+    fresh_row = Repo.get!(BridgeAffinity, fresh.affinity.row.id)
+    succeed(first, a)
+    assert Repo.get!(BridgeAffinity, fresh_row.id) == fresh_row
+  end
+
+  test "successful completion alone renews idle retention", context do
+    first = plan(context, options())
+    older_expiry = DateTime.add(first.affinity.row.expires_at, -100, :second)
+    Repo.update!(Ecto.Changeset.change(first.affinity.row, expires_at: older_expiry))
+    planned = plan(context, options())
+    assert planned.affinity.row.expires_at == older_expiry
+    succeed(planned, hd(planned.candidates))
+
+    assert DateTime.after?(
+             Repo.get!(BridgeAffinity, first.affinity.row.id).expires_at,
+             older_expiry
+           )
+  end
+
+  defp durable_rows,
+    do: from(affinity in BridgeAffinity, where: affinity.affinity_kind == "durable_conversation")
+
+  defp ingress_options(window, turn, conversation) do
+    Phoenix.ConnTest.build_conn(:post, "/backend-api/codex/responses")
+    |> Plug.Conn.put_req_header("x-codex-window-id", window)
+    |> Plug.Conn.put_req_header("x-codex-turn-state", turn)
+    |> Plug.Conn.put_req_header("thread-id", conversation)
+    |> Plug.Conn.put_req_header("session-id", "shared-root")
+    |> GatewayControllerHelpers.request_opts()
+    |> RequestOptions.build("/backend-api/codex/responses", %{})
+  end
+
+  defp options(overrides \\ %{}, payload \\ %{}) do
+    %{session_header_source: "x-codex-conversation-id", session_header: "conversation-fixture"}
+    |> Map.merge(overrides)
+    |> RequestOptions.build("/backend-api/codex/responses", payload)
+  end
+
+  defp plan(context, opts) do
+    BridgeRing.plan_route(%{
+      auth: context.auth,
+      model: context.model,
+      candidates: context.candidates,
+      request_options: opts,
+      route_plan_input: %RoutePlanInput{correlation_id: Ecto.UUID.generate()}
+    })
+  end
+
+  defp succeed(plan, {assignment, identity}),
+    do: BridgeRing.record_success(plan, assignment, identity)
+end

--- a/test/codex_pooler/runtime_state_cleanup_test.exs
+++ b/test/codex_pooler/runtime_state_cleanup_test.exs
@@ -68,6 +68,7 @@ defmodule CodexPooler.RuntimeStateCleanupTest do
 
     assert summary == %{
              expired_aliases: 1,
+             expired_conversation_affinities: 0,
              expired_idempotency_keys: 1,
              expired_owner_leases: 1,
              expired_owner_sessions_recovered: 0

--- a/test/codex_pooler_web/controllers/runtime/durable_affinity_controller_test.exs
+++ b/test/codex_pooler_web/controllers/runtime/durable_affinity_controller_test.exs
@@ -1,0 +1,148 @@
+defmodule CodexPoolerWeb.Runtime.DurableAffinityControllerTest do
+  use CodexPoolerWeb.ConnCase, async: false
+
+  import Ecto.Query
+  import CodexPoolerWeb.Runtime.BackendCodexTestSupport
+
+  alias CodexPooler.Accounting.Attempt
+  alias CodexPooler.FakeUpstream
+
+  alias CodexPooler.Gateway.Persistence.{
+    BridgeAffinity,
+    BridgeDemotion,
+    CodexSession,
+    RoutingCircuitState
+  }
+
+  alias CodexPooler.Pools
+  alias CodexPooler.Repo
+
+  for failure_status <- [429, 503, :quota] do
+    test "HTTP #{failure_status} failover persists across session recreation and account recovery",
+         %{conn: conn} do
+      a_server = start_upstream(success("a"))
+      b_server = start_upstream(success("b"))
+      setup = gateway_setup(a_server)
+      b = gateway_upstream(setup.pool, b_server, "synthetic-b-token", [])
+      prime_routing_quota!(b.identity)
+
+      setup = %{
+        setup
+        | model: put_model_source_assignments!(setup.model, [setup.assignment, b.assignment])
+      }
+
+      Pools.ensure_routing_settings(setup.pool)
+      |> Ecto.Changeset.change(durable_conversation_affinity_enabled: true)
+      |> Repo.update!()
+
+      payload = %{
+        "model" => setup.model.exposed_model_id,
+        "input" => native_text_input("synthetic conversation"),
+        "prompt_cache_key" => "unmodified-client-cache",
+        "stream" => false
+      }
+
+      assert json_response(call(conn, setup, payload, "window-a"), 200)["id"] in [
+               "resp-a",
+               "resp-b"
+             ]
+
+      row = Repo.one!(from a in BridgeAffinity, where: a.affinity_kind == "durable_conversation")
+
+      {old, fallback, old_server, fallback_server} =
+        if row.pool_upstream_assignment_id == setup.assignment.id,
+          do: {%{assignment: setup.assignment, identity: setup.identity}, b, a_server, b_server},
+          else: {b, %{assignment: setup.assignment, identity: setup.identity}, b_server, a_server}
+
+      if unquote(failure_status) == :quota do
+        prime_exhausted_routing_quota!(old.identity)
+      else
+        FakeUpstream.set_mode(
+          old_server,
+          FakeUpstream.json_response(
+            %{"error" => %{"message" => "synthetic failure", "type" => "server_error"}},
+            unquote(failure_status)
+          )
+        )
+      end
+
+      count_before_failure = FakeUpstream.count(old_server)
+
+      assert json_response(call(conn, setup, payload, "window-b"), 200)["id"] in [
+               "resp-a",
+               "resp-b"
+             ]
+
+      assert Repo.reload!(row).pool_upstream_assignment_id == fallback.assignment.id
+
+      if unquote(failure_status) == :quota do
+        assert FakeUpstream.count(old_server) == count_before_failure
+      else
+        assert Repo.exists?(
+                 from a in Attempt,
+                   where:
+                     a.pool_upstream_assignment_id == ^old.assignment.id and
+                       a.status == "retryable_failed"
+               )
+      end
+
+      expired_at = DateTime.add(DateTime.utc_now(), -120, :second)
+
+      previous_ids =
+        Repo.all(from s in CodexSession, where: s.pool_id == ^setup.pool.id, select: s.id)
+
+      Repo.update_all(from(s in CodexSession, where: s.pool_id == ^setup.pool.id),
+        set: [owner_lease_expires_at: expired_at]
+      )
+
+      FakeUpstream.set_mode(old_server, success("recovered"))
+
+      Repo.reload!(old.assignment)
+      |> Ecto.Changeset.change(health_status: "active", cooldown_until: nil)
+      |> Repo.update!()
+
+      Repo.delete_all(from d in BridgeDemotion, where: d.pool_id == ^setup.pool.id)
+      Repo.delete_all(from c in RoutingCircuitState, where: c.pool_id == ^setup.pool.id)
+      prime_routing_quota!(old.identity)
+      count_old = FakeUpstream.count(old_server)
+      count_fallback = FakeUpstream.count(fallback_server)
+
+      assert json_response(call(conn, setup, payload, "window-b"), 200)["id"] in [
+               "resp-a",
+               "resp-b"
+             ]
+
+      assert FakeUpstream.count(old_server) == count_old
+      assert FakeUpstream.count(fallback_server) == count_fallback + 1
+
+      assert Repo.exists?(
+               from s in CodexSession,
+                 where: s.pool_id == ^setup.pool.id and s.id not in ^previous_ids
+             )
+
+      for request <- FakeUpstream.requests(a_server) ++ FakeUpstream.requests(b_server) do
+        assert request.json["prompt_cache_key"] == payload["prompt_cache_key"]
+      end
+    end
+  end
+
+  defp call(conn, setup, payload, window) do
+    conn
+    |> recycle()
+    |> auth(setup)
+    |> put_req_header("thread-id", "synthetic-thread")
+    |> put_req_header("session-id", "root-session")
+    |> put_req_header("x-codex-window-id", window)
+    |> post("/backend-api/codex/responses", payload)
+  end
+
+  defp success(account) do
+    FakeUpstream.json_response(%{
+      "id" => "resp-#{account}",
+      "object" => "response",
+      "status" => "completed",
+      "output" => [],
+      "usage" => %{"input_tokens" => 2, "output_tokens" => 1, "total_tokens" => 3}
+    })
+  end
+end

--- a/test/codex_pooler_web/live/admin/pages/pools_live_test.exs
+++ b/test/codex_pooler_web/live/admin/pages/pools_live_test.exs
@@ -4035,6 +4035,8 @@ defmodule CodexPoolerWeb.Admin.PoolsLiveTest do
         "id" => pool.id,
         "name" => "Editable Routing",
         "status" => "active",
+        "durable_conversation_affinity_enabled" => "true",
+        "durable_conversation_affinity_idle_seconds" => "3600",
         "routing_strategy" => "quota_first",
         "bridge_ring_size" => "5",
         "sticky_websocket_sessions" => "false",
@@ -4050,6 +4052,15 @@ defmodule CodexPoolerWeb.Admin.PoolsLiveTest do
     settings = Pools.get_routing_settings(pool)
     assert settings.routing_strategy == "quota_first"
     assert settings.bridge_ring_size == 5
+    assert settings.durable_conversation_affinity_enabled
+    assert settings.durable_conversation_affinity_idle_seconds == 3600
+    assert has_element?(view, "#pool_edit_durable_conversation_affinity_enabled[checked]")
+
+    assert has_element?(
+             view,
+             "#pool_edit_durable_conversation_affinity_idle_seconds[value='3600']"
+           )
+
     assert settings.sticky_websocket_sessions == false
     assert settings.sticky_http_sessions == true
     assert settings.prompt_cache_affinity_enabled == false


### PR DESCRIPTION
When a conversation pauses long enough for its transport session to expire, its next request can select a different account even though the previous account remains eligible. This adds optional per-pool conversation affinity in PostgreSQL so the same conversation can keep its account across idle session recreation and requests handled by different application processes.

The setting is off by default. Enabling it uses `thread-id`, then `x-codex-conversation-id` when the first header is absent. Codex's root-shared `session-id`, window IDs, turn state and prompt-cache keys are not treated as conversation identity. Stored keys are typed digests scoped to the pool, API key and exposed model; outgoing payloads and `prompt_cache_key` are unchanged.

The preference only reorders eligible candidates. Existing previous-response/file constraints, active upstream WebSocket pins, quota/health exclusions and retry rules retain priority. The first reservation converges under concurrent requests, and successful failover updates the remembered account. A row-ID/generation fence prevents an old completion from moving it back or overwriting a recreated row. Owner leases remain a separate mechanism; this PR does not depend on #364's code.

Retention defaults to one day, accepts 60 seconds to 30 days, and renews only on successful completion. Expired mappings are ignored immediately and removed in indexed batches of at most 1,000. Disabling applies to new route plans; already admitted plans may finish fenced bookkeeping. The migration extends the existing affinity table and pool settings. Rollback removes only the new affinity kind and fields, preserving legacy rows.

Validation:

- Full ordinary suite through `make test-fast N=4`: all four partitions pass. An initial run exposed the existing cleanup-summary assertion's missing new zero-valued counter; that contract assertion is updated.
- Unix integration profile: 59 tests pass.
- New focused coverage includes independent PostgreSQL transactions, initial reservation contention, stale completion after failover, lock waits past expiry, session recreation, scope/header validation, quota exclusion, actual HTTP 429/503 failover and no bounceback after account recovery. Existing LiveView coverage submits and reloads the new settings.
- Disposable PostgreSQL 18 migration up/down/up preserves legacy rows/settings and parent records; restored defaults, index and retention bounds are verified.
- Format, compile with warnings as errors, xref, strict Credo, docs check/build and independent source review pass.

Cross-process coordination is tested using separate committed PostgreSQL connections, not a production multi-node cluster. Account affinity may improve cache locality; it does not guarantee provider cache hits or transfer provider state between accounts. No production rollout is included.
