### PR TITLE
fix: reject imports prepared before a credential replacement

### DIFF
--- a/dev_support/codex_pooler/dev/upstream_account_bundle.ex
+++ b/dev_support/codex_pooler/dev/upstream_account_bundle.ex
@@ -10,7 +10,6 @@ defmodule CodexPooler.Dev.UpstreamAccountBundle do
   alias CodexPooler.Repo
   alias CodexPooler.Upstreams
   alias CodexPooler.Upstreams.Auth.TokenRefreshMetadata
-  alias CodexPooler.Upstreams.Lifecycle.IdentitySlotLock
   alias CodexPooler.Upstreams.PreparedAccount
   alias CodexPooler.Upstreams.Secrets
   alias CodexPooler.Upstreams.TokenLinking
@@ -314,7 +313,9 @@ defmodule CodexPooler.Dev.UpstreamAccountBundle do
           true
         )
 
-      case CodexPooler.JSON.encode(Map.put(header, "ciphertext", Base.encode64(tag <> ciphertext))) do
+      case CodexPooler.JSON.encode(
+             Map.put(header, "ciphertext", Base.encode64(tag <> ciphertext))
+           ) do
         {:ok, bundle} -> {:ok, bundle}
         {:error, _reason} -> {:error, lifecycle_error(:bundle_encoding_failed)}
       end
@@ -483,16 +484,10 @@ defmodule CodexPooler.Dev.UpstreamAccountBundle do
   end
 
   defp import_accounts_transaction(prepared_accounts, pool, scope) do
-    IdentitySlotLock.lock_slots!(Enum.map(prepared_accounts, & &1.attrs))
-
-    prepared_accounts
-    |> Enum.reduce_while([], fn prepared, results ->
-      case TokenLinking.link_prepared_in_transaction(scope, pool, prepared, slots_locked?: true) do
-        {:ok, result} -> {:cont, [result | results]}
-        {:error, _reason} -> Repo.rollback(:bundle_import_failed)
-      end
-    end)
-    |> Enum.reverse()
+    case TokenLinking.link_prepared_batch_in_transaction(scope, pool, prepared_accounts) do
+      {:ok, results} -> results
+      {:error, _reason} -> Repo.rollback(:bundle_import_failed)
+    end
   end
 
   defp publish_import_results(results, pool, scope) do

--- a/lib/codex_pooler/upstreams/import.ex
+++ b/lib/codex_pooler/upstreams/import.ex
@@ -67,8 +67,10 @@ defmodule CodexPooler.Upstreams.Import do
   @spec prepare_trusted_account(Scope.t(), Pool.t(), map()) ::
           {:ok, PreparedAccount.t()} | {:error, Ecto.Changeset.t() | lifecycle_error()}
   def prepare_trusted_account(%Scope{} = scope, %Pool{} = pool, attrs) when is_map(attrs) do
-    with {:ok, attrs} <- validate_trusted_account(scope, pool, attrs) do
-      PreparedAccount.prepare(scope, pool, attrs, trusted_account_link_options(attrs))
+    with {:ok, attrs} <- validate_trusted_account(scope, pool, attrs),
+         {:ok, prepared} <-
+           PreparedAccount.prepare(scope, pool, attrs, trusted_account_link_options(attrs)) do
+      PreparedAccount.capture_import(prepared)
     end
   end
 
@@ -78,8 +80,10 @@ defmodule CodexPooler.Upstreams.Import do
   @spec prepare_bundle_account(Scope.t(), Pool.t(), map()) ::
           {:ok, PreparedAccount.t()} | {:error, Ecto.Changeset.t() | lifecycle_error()}
   def prepare_bundle_account(%Scope{} = scope, %Pool{} = pool, attrs) when is_map(attrs) do
-    with {:ok, attrs} <- validate_trusted_account(scope, pool, attrs) do
-      PreparedAccount.prepare_bundle(scope, pool, attrs, trusted_account_link_options(attrs))
+    with {:ok, attrs} <- validate_trusted_account(scope, pool, attrs),
+         {:ok, prepared} <-
+           PreparedAccount.prepare_bundle(scope, pool, attrs, trusted_account_link_options(attrs)) do
+      PreparedAccount.capture_import(prepared)
     end
   end
 
@@ -147,14 +151,19 @@ defmodule CodexPooler.Upstreams.Import do
   end
 
   defp do_import_codex_auth_json_account(%Scope{} = scope, %Pool{} = pool, attrs) do
-    TokenLinking.link_tokens(scope, pool, attrs,
+    opts = [
       onboarding_method: "import",
       credential_provenance: :codex_chatgpt,
       audit_action: "upstream_account.import",
       broadcast_reason: "upstream_account_imported",
       quota_trigger_kind: "account_link",
       token_refresh_trigger_kind: "auth_json_import"
-    )
+    ]
+
+    with {:ok, prepared} <- PreparedAccount.prepare(scope, pool, attrs, opts),
+         {:ok, prepared} <- PreparedAccount.capture_import(prepared) do
+      TokenLinking.link_prepared(scope, pool, prepared, opts)
+    end
   end
 
   defp normalize_import_attrs(attrs) do

--- a/lib/codex_pooler/upstreams/prepared_account.ex
+++ b/lib/codex_pooler/upstreams/prepared_account.ex
@@ -5,6 +5,10 @@ defmodule CodexPooler.Upstreams.PreparedAccount do
   alias CodexPooler.Pools
   alias CodexPooler.Pools.Pool
   alias CodexPooler.Upstreams.Auth.AccessTokenExpiry
+  alias CodexPooler.Upstreams.Lifecycle.CredentialFencing
+  alias CodexPooler.Upstreams.Lifecycle.IdentityLifecycle
+  alias CodexPooler.Upstreams.Lifecycle.IdentitySlotLock
+  alias CodexPooler.Upstreams.Schemas.UpstreamIdentity
 
   @reserved_attr_keys ~w(credential_policy prepared_account __prepared_account__)a
   @reserved_string_keys Enum.map(@reserved_attr_keys, &Atom.to_string/1)
@@ -15,11 +19,62 @@ defmodule CodexPooler.Upstreams.PreparedAccount do
           pool_id: Ecto.UUID.t(),
           attrs: map(),
           expiry: AccessTokenExpiry.resolution(),
-          policy: policy()
+          policy: policy(),
+          import_snapshot: map() | :absent | {:error, term()} | nil
         }
 
   @enforce_keys [:scope_user_id, :pool_id, :attrs, :expiry, :policy]
-  defstruct [:scope_user_id, :pool_id, :attrs, :expiry, :policy]
+  defstruct [:scope_user_id, :pool_id, :attrs, :expiry, :policy, :import_snapshot]
+
+  # Only import entry points opt in. OAuth and invite preparation retain their
+  # existing replacement semantics. Capture before waiting for persistence locks.
+  @spec capture_import(t()) :: {:ok, t()} | {:error, term()}
+  def capture_import(%__MODULE__{} = prepared) do
+    snapshot =
+      with {:ok, identity} <- IdentityLifecycle.select_upsert_identity(prepared.attrs),
+           {:ok, snapshot} <- import_snapshot(identity),
+           do: snapshot
+
+    # Retain selection/epoch errors until persistence, preserving import and
+    # bundle validation error semantics without admitting an invalid snapshot.
+    {:ok, %{prepared | import_snapshot: snapshot}}
+  end
+
+  # The caller holds both the canonical slot and credential replacement locks.
+  @spec validate_import_snapshot(t(), UpstreamIdentity.t() | nil) ::
+          :ok | {:error, %{code: atom(), message: String.t()}}
+  def validate_import_snapshot(%__MODULE__{import_snapshot: nil}, _identity), do: :ok
+
+  def validate_import_snapshot(%__MODULE__{import_snapshot: {:error, reason}}, _identity),
+    do: {:error, reason}
+
+  def validate_import_snapshot(%__MODULE__{import_snapshot: expected}, identity) do
+    with {:ok, current} <- import_snapshot(identity) do
+      if expected == current,
+        do: :ok,
+        else:
+          {:error,
+           %{
+             code: :stale_import,
+             message: "account credentials changed while importing; submit the import again"
+           }}
+    end
+  end
+
+  defp import_snapshot(nil), do: {:ok, :absent}
+
+  defp import_snapshot(%UpstreamIdentity{} = identity) do
+    with {:ok, epoch} <- CredentialFencing.validate_current_credential_epoch(identity) do
+      {:ok,
+       %{
+         identity_id: identity.id,
+         slot: IdentitySlotLock.normalize(identity),
+         credential_epoch: epoch,
+         # First activation of a pending identity keeps its initial epoch.
+         pending?: identity.status == "pending"
+       }}
+    end
+  end
 
   @spec prepare(Scope.t(), Pool.t(), map(), keyword()) ::
           {:ok, t()} | {:error, %{code: atom(), message: String.t()}}

--- a/lib/codex_pooler/upstreams/token_linking.ex
+++ b/lib/codex_pooler/upstreams/token_linking.ex
@@ -119,6 +119,69 @@ defmodule CodexPooler.Upstreams.TokenLinking do
   def link_prepared_in_transaction(_scope, _pool, _prepared, _opts),
     do: {:error, lifecycle_error(:invalid_request, "token linking request is invalid")}
 
+  @spec link_prepared_batch_in_transaction(Scope.t(), Pool.t(), [PreparedAccount.t()]) ::
+          {:ok, [link_success()]} | {:error, lifecycle_error()}
+  def link_prepared_batch_in_transaction(%Scope{} = scope, %Pool{} = pool, prepared_accounts)
+      when is_list(prepared_accounts) do
+    if Repo.in_transaction?() do
+      validate_import_batch!(scope, pool, prepared_accounts)
+
+      # All snapshots were checked before any writes, with every slot/identity
+      # lock retained. Duplicate entries may now replace earlier batch entries.
+      results =
+        Enum.map(prepared_accounts, fn prepared ->
+          persist_prepared!(scope, pool, %{prepared | import_snapshot: nil}, true)
+        end)
+
+      {:ok, results}
+    else
+      {:error,
+       lifecycle_error(:transaction_required, "token linking requires a caller-owned transaction")}
+    end
+  end
+
+  defp validate_import_batch!(scope, pool, prepared_accounts) do
+    Enum.each(prepared_accounts, fn prepared ->
+      case PreparedAccount.validate(prepared, scope, pool) do
+        {:ok, _prepared} -> :ok
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+
+    IdentitySlotLock.lock_slots!(Enum.map(prepared_accounts, & &1.attrs))
+
+    identities = Enum.map(prepared_accounts, &select_prepared_identity!/1)
+
+    locked =
+      identities
+      |> CredentialFencing.lock_credential_replacements()
+      |> Map.new(&{&1.id, &1})
+
+    Enum.each(prepared_accounts, fn prepared ->
+      identity = select_prepared_identity!(prepared)
+
+      # Slot locks serialize canonical selection with other credential writers.
+      # Never validate a newly selected row that was not part of our lock set.
+      if identity && not Map.has_key?(locked, identity.id) do
+        Repo.rollback(lifecycle_error(:stale_import, "account identity changed while importing"))
+      end
+
+      identity = if identity, do: Map.fetch!(locked, identity.id)
+
+      case PreparedAccount.validate_import_snapshot(prepared, identity) do
+        :ok -> :ok
+        {:error, reason} -> Repo.rollback(reason)
+      end
+    end)
+  end
+
+  defp select_prepared_identity!(prepared) do
+    case select_link_identity(prepared.attrs, incoming_identity_attrs(prepared.attrs)) do
+      {:ok, identity} -> identity
+      {:error, reason} -> Repo.rollback(reason)
+    end
+  end
+
   @spec publish_link_result(Scope.t(), Pool.t(), link_success(), keyword()) :: link_result()
   def publish_link_result(%Scope{} = scope, %Pool{} = pool, %{} = result, opts)
       when is_list(opts) do
@@ -211,7 +274,8 @@ defmodule CodexPooler.Upstreams.TokenLinking do
       {:ok, %UpstreamIdentity{} = identity} ->
         identity = CredentialFencing.lock_credential_replacement(identity)
 
-        with {:ok, replacement_metadata, epoch} <-
+        with :ok <- PreparedAccount.validate_import_snapshot(prepared, identity),
+             {:ok, replacement_metadata, epoch} <-
                CredentialFencing.prepare_replacement_metadata(identity),
              :ok <- PreparedAccount.evaluate(prepared, now()),
              attrs =
@@ -228,7 +292,8 @@ defmodule CodexPooler.Upstreams.TokenLinking do
         end
 
       {:ok, nil} ->
-        with :ok <- PreparedAccount.evaluate(prepared, now()),
+        with :ok <- PreparedAccount.validate_import_snapshot(prepared, nil),
+             :ok <- PreparedAccount.evaluate(prepared, now()),
              identity_attrs = new_identity_replacement_attrs(identity_attrs, prepared, timestamp),
              {:ok, identity} <-
                create_identity_with_plan(Map.put(identity_attrs, :status, @pending)),

--- a/test/codex_pooler/upstreams/import_fencing_test.exs
+++ b/test/codex_pooler/upstreams/import_fencing_test.exs
@@ -1,0 +1,508 @@
+defmodule CodexPooler.Upstreams.ImportFencingTest do
+  use ExUnit.Case, async: false
+
+  import CodexPooler.AccountsFixtures
+  import CodexPooler.PoolerFixtures
+  import Ecto.Query
+
+  alias CodexPooler.Accounts.Scope
+  alias CodexPooler.Audit.AuditEvent
+  alias CodexPooler.Dev.UpstreamAccountBundle
+  alias CodexPooler.Pools.Pool
+  alias CodexPooler.Repo
+  alias CodexPooler.Upstreams
+  alias CodexPooler.Upstreams.Auth.{CodexAuth, TokenRefresh}
+  alias CodexPooler.Upstreams.Lifecycle.IdentitySlotLock
+  alias CodexPooler.Upstreams.PreparedAccount
+  alias CodexPooler.Upstreams.Schemas.{EncryptedSecret, PoolUpstreamAssignment, UpstreamIdentity}
+  alias CodexPooler.Upstreams.Secrets
+  alias CodexPooler.Upstreams.TokenLinking
+  alias Ecto.Adapters.SQL.Sandbox
+
+  defmodule RefreshClient do
+    def refresh_token(_token, _opts) do
+      {:ok,
+       %{
+         access_token: "synthetic-rotated-access",
+         refresh_token: "synthetic-rotated-refresh",
+         expires_in: 3600
+       }}
+    end
+  end
+
+  setup do
+    :ok = Sandbox.checkout(Repo, sandbox: false)
+    old_auth = Application.fetch_env(:codex_pooler, CodexAuth)
+    Application.put_env(:codex_pooler, CodexAuth, client: RefreshClient)
+    %{user: user} = bootstrap_owner_fixture()
+    pool = pool_fixture(%{created_by_user_id: user.id})
+    account_id = "import-fence-#{Ecto.UUID.generate()}"
+
+    attrs = %{
+      chatgpt_account_id: account_id,
+      account_email: "#{account_id}@example.invalid",
+      account_label: "Import fencing fixture",
+      token: jwt(%{"exp" => DateTime.to_unix(DateTime.utc_now()) + 3600}),
+      refresh_token: "synthetic-original-refresh",
+      credential_provenance: "codex_chatgpt_oauth"
+    }
+
+    on_exit(fn ->
+      case old_auth do
+        {:ok, config} -> Application.put_env(:codex_pooler, CodexAuth, config)
+        :error -> Application.delete_env(:codex_pooler, CodexAuth)
+      end
+
+      Sandbox.unboxed_run(Repo, fn ->
+        Repo.delete_all(from pool in Pool, where: pool.id == ^pool.id)
+
+        Repo.delete_all(
+          from identity in UpstreamIdentity, where: identity.chatgpt_account_id == ^account_id
+        )
+      end)
+    end)
+
+    %{scope: Scope.for_user(user), pool: pool, attrs: attrs}
+  end
+
+  test "public auth-json import waiting on a slot lock cannot overwrite a committed refresh", %{
+    scope: scope,
+    pool: pool,
+    attrs: attrs
+  } do
+    content = exported(attrs)
+    assert {:ok, %{identity: identity}} = Upstreams.import_codex_auth_json(scope, pool, content)
+    parent = self()
+
+    holder =
+      Task.async(fn ->
+        Sandbox.unboxed_run(Repo, fn ->
+          Repo.transaction(fn ->
+            IdentitySlotLock.lock_slots!([attrs])
+            send(parent, :slot_locked)
+
+            receive do
+              :release -> :ok
+            after
+              15_000 -> raise "slot lock barrier timed out"
+            end
+          end)
+        end)
+      end)
+
+    assert_receive :slot_locked, 5_000
+
+    importer =
+      Task.async(fn ->
+        Sandbox.unboxed_run(Repo, fn ->
+          %{rows: [[backend_pid]]} = Repo.query!("SELECT pg_backend_pid()")
+          send(parent, {:import_started, backend_pid})
+          Upstreams.import_codex_auth_json(scope, pool, content)
+        end)
+      end)
+
+    try do
+      assert_receive {:import_started, backend_pid}, 5_000
+      wait_advisory!(backend_pid, 500)
+      assert Task.yield(importer, 0) == nil
+      assert {:ok, %{status: :active}} = TokenRefresh.refresh_access_token(identity)
+      refreshed = Repo.reload!(identity)
+      assert refreshed.metadata["credential_epoch"] == 2
+      send(holder.pid, :release)
+      assert {:ok, :ok} = Task.await(holder, 5_000)
+
+      assert {:error, %{code: :stale_import}} = Task.await(importer, 5_000)
+      assert Repo.reload!(identity) == refreshed
+      assert_rotated_pair(identity)
+    after
+      Task.shutdown(holder, :brutal_kill)
+      Task.shutdown(importer, :brutal_kill)
+    end
+  end
+
+  test "a new explicit old export submitted after refresh remains a replacement", %{
+    scope: scope,
+    pool: pool,
+    attrs: attrs
+  } do
+    content = exported(attrs)
+    assert {:ok, %{identity: identity}} = Upstreams.import_codex_auth_json(scope, pool, content)
+    assert {:ok, %{status: :active}} = TokenRefresh.refresh_access_token(identity)
+    assert {:ok, %{identity: imported}} = Upstreams.import_codex_auth_json(scope, pool, content)
+    assert imported.metadata["credential_epoch"] == 3
+    assert {:ok, token} = Secrets.decrypt_active_secret(identity, "refresh_token")
+    assert token == attrs.refresh_token
+  end
+
+  test "an absent slot snapshot rejects a competing initial import", context do
+    %{scope: scope, pool: pool, attrs: attrs} = context
+    assert {:ok, prepared} = Upstreams.prepare_trusted_account(scope, pool, attrs)
+    assert {:ok, %{identity: identity}} = Upstreams.import_trusted_account(scope, pool, attrs)
+    before = persistence_counts()
+
+    assert {:error, %{code: :stale_import}} =
+             TokenLinking.link_prepared(scope, pool, prepared, [])
+
+    assert persistence_counts() == before
+    assert Repo.reload!(identity).metadata["credential_epoch"] == 1
+  end
+
+  test "input attrs cannot supply or disable the internal import snapshot", context do
+    %{scope: scope, pool: pool, attrs: attrs} = context
+    assert {:ok, %{identity: identity}} = Upstreams.import_trusted_account(scope, pool, attrs)
+    injected = attrs |> Map.put(:import_snapshot, nil) |> Map.put("import_snapshot", :absent)
+    assert {:ok, prepared} = Upstreams.prepare_trusted_account(scope, pool, injected)
+    refute inspect(prepared) =~ attrs.token
+    assert {:ok, %{status: :active}} = TokenRefresh.refresh_access_token(identity)
+
+    assert {:error, %{code: :stale_import} = error} =
+             TokenLinking.link_prepared(scope, pool, prepared, [])
+
+    refute inspect(error) =~ attrs.token
+    refute inspect(error) =~ attrs.refresh_token
+    assert_rotated_pair(identity)
+  end
+
+  test "a pending snapshot rejects initial activation even when epoch stays one", context do
+    %{scope: scope, pool: pool, attrs: attrs} = context
+
+    identity =
+      attrs
+      |> Map.put(:credential_provenance, :codex_chatgpt)
+      |> Map.put(:metadata, %{"credential_epoch" => 1})
+      |> upstream_identity_fixture()
+
+    assert identity.status == "pending"
+    assert {:ok, prepared} = Upstreams.prepare_trusted_account(scope, pool, attrs)
+    assert {:ok, %{identity: activated}} = Upstreams.import_trusted_account(scope, pool, attrs)
+    assert activated.metadata["credential_epoch"] == 1
+
+    assert {:error, %{code: :stale_import}} =
+             TokenLinking.link_prepared(scope, pool, prepared, [])
+
+    assert Repo.reload!(identity) == activated
+  end
+
+  test "deleted or replaced canonical identity cannot reuse the old snapshot", context do
+    %{scope: scope, pool: pool, attrs: attrs} = context
+    assert {:ok, %{identity: identity}} = Upstreams.import_trusted_account(scope, pool, attrs)
+    assert {:ok, prepared} = Upstreams.prepare_trusted_account(scope, pool, attrs)
+    Repo.delete!(identity)
+
+    assert {:error, %{code: :stale_import}} =
+             TokenLinking.link_prepared(scope, pool, prepared, [])
+
+    assert {:ok, %{identity: replacement}} = Upstreams.import_trusted_account(scope, pool, attrs)
+    assert replacement.id != identity.id
+
+    assert {:error, %{code: :stale_import}} =
+             TokenLinking.link_prepared(scope, pool, prepared, [])
+
+    assert Repo.reload!(replacement).metadata["credential_epoch"] == 1
+  end
+
+  test "same row and epoch with changed canonical evidence rejects the old snapshot", context do
+    %{scope: scope, pool: pool, attrs: attrs} = context
+    assert {:ok, %{identity: identity}} = Upstreams.import_trusted_account(scope, pool, attrs)
+    assert {:ok, prepared} = Upstreams.prepare_trusted_account(scope, pool, attrs)
+
+    updated =
+      identity
+      |> Ecto.Changeset.change(account_email: "changed@example.invalid")
+      |> Repo.update!()
+
+    assert {:error, %{code: :stale_import}} =
+             TokenLinking.link_prepared(scope, pool, prepared, [])
+
+    assert Repo.reload!(identity) == updated
+  end
+
+  test "missing legacy epoch remains epoch one but concurrent refresh still fences it", context do
+    %{scope: scope, pool: pool, attrs: attrs} = context
+    assert {:ok, %{identity: identity}} = Upstreams.import_trusted_account(scope, pool, attrs)
+
+    identity =
+      identity
+      |> Ecto.Changeset.change(metadata: Map.delete(identity.metadata, "credential_epoch"))
+      |> Repo.update!()
+
+    assert {:ok, prepared} = Upstreams.prepare_trusted_account(scope, pool, attrs)
+    assert {:ok, %{status: :active}} = TokenRefresh.refresh_access_token(identity)
+
+    assert {:error, %{code: :stale_import}} =
+             TokenLinking.link_prepared(scope, pool, prepared, [])
+
+    assert_rotated_pair(identity)
+
+    current = Repo.reload!(identity)
+
+    current
+    |> Ecto.Changeset.change(metadata: Map.delete(current.metadata, "credential_epoch"))
+    |> Repo.update!()
+
+    assert {:ok, %{identity: imported}} = Upstreams.import_trusted_account(scope, pool, attrs)
+    assert imported.metadata["credential_epoch"] == 2
+  end
+
+  test "invalid epochs at preparation or persistence never rotate credentials", context do
+    %{scope: scope, pool: pool, attrs: attrs} = context
+    assert {:ok, %{identity: identity}} = Upstreams.import_trusted_account(scope, pool, attrs)
+
+    for epoch <- [nil, 0, -1, "1", 1.5] do
+      identity
+      |> Ecto.Changeset.change(metadata: Map.put(identity.metadata, "credential_epoch", epoch))
+      |> Repo.update!()
+
+      assert {:ok, prepared} = Upstreams.prepare_trusted_account(scope, pool, attrs)
+      before = persistence_counts()
+
+      assert {:error, %{code: :invalid_credential_epoch}} =
+               TokenLinking.link_prepared(scope, pool, prepared, [])
+
+      assert persistence_counts() == before
+
+      Repo.update!(
+        Ecto.Changeset.change(identity,
+          metadata: Map.put(identity.metadata, "credential_epoch", 2)
+        )
+      )
+
+      assert {:error, %{code: :invalid_credential_epoch}} =
+               TokenLinking.link_prepared(scope, pool, prepared, [])
+    end
+
+    assert {:ok, prepared} = Upstreams.prepare_trusted_account(scope, pool, attrs)
+
+    identity
+    |> Ecto.Changeset.change(metadata: Map.put(identity.metadata, "credential_epoch", false))
+    |> Repo.update!()
+
+    assert {:error, %{code: :invalid_credential_epoch}} =
+             TokenLinking.link_prepared(scope, pool, prepared, [])
+
+    assert {:ok, token} = Secrets.decrypt_active_secret(identity, "refresh_token")
+    assert token == attrs.refresh_token
+  end
+
+  test "ordinary OAuth and invite preparation retain replacement semantics", context do
+    %{scope: scope, pool: pool, attrs: attrs} = context
+    assert {:ok, %{identity: identity}} = Upstreams.import_trusted_account(scope, pool, attrs)
+
+    for method <- ["browser", "device", "invite"] do
+      assert {:ok, prepared} =
+               PreparedAccount.prepare(scope, pool, attrs, onboarding_method: method)
+
+      assert {:ok, %{status: :active}} = TokenRefresh.refresh_access_token(identity)
+      assert {:ok, %{identity: imported}} = TokenLinking.link_prepared(scope, pool, prepared, [])
+      assert imported.onboarding_method == method
+    end
+  end
+
+  test "canonical workspace slots and noncredential health changes remain independent", context do
+    %{scope: scope, pool: pool, attrs: attrs} = context
+    first = Map.put(attrs, :workspace_id, "workspace-first")
+    second = Map.put(attrs, :workspace_id, "workspace-second")
+    assert {:ok, %{identity: a}} = Upstreams.import_trusted_account(scope, pool, first)
+    assert {:ok, %{identity: b}} = Upstreams.import_trusted_account(scope, pool, second)
+    assert {:ok, prepared} = Upstreams.prepare_trusted_account(scope, pool, first)
+    Repo.update!(Ecto.Changeset.change(a, status: "refresh_due"))
+    assert {:ok, %{status: :active}} = TokenRefresh.refresh_access_token(b)
+    assert {:ok, %{identity: imported}} = TokenLinking.link_prepared(scope, pool, prepared, [])
+    assert imported.id == a.id
+    assert_rotated_pair(b)
+  end
+
+  test "batch rejects a stale later entry before any credential or side effect writes", context do
+    %{scope: scope, pool: pool, attrs: attrs} = context
+    first = Map.put(attrs, :workspace_id, "workspace-first")
+    second = Map.put(attrs, :workspace_id, "workspace-second")
+    assert {:ok, fresh} = Upstreams.prepare_bundle_account(scope, pool, first)
+    assert {:ok, %{identity: identity}} = Upstreams.import_trusted_account(scope, pool, second)
+    assert {:ok, stale} = Upstreams.prepare_bundle_account(scope, pool, second)
+    assert {:ok, %{status: :active}} = TokenRefresh.refresh_access_token(identity)
+    before = persistence_counts()
+
+    assert {:error, %{code: :stale_import}} =
+             Repo.transaction(fn ->
+               TokenLinking.link_prepared_batch_in_transaction(scope, pool, [fresh, stale])
+             end)
+
+    assert persistence_counts() == before
+    assert_rotated_pair(identity)
+  end
+
+  test "batch duplicate entries retain order for absent and existing canonical slots", context do
+    %{scope: scope, pool: pool, attrs: attrs} = context
+
+    for _state <- [:absent, :existing] do
+      assert {:ok, first} = Upstreams.prepare_bundle_account(scope, pool, attrs)
+
+      replacement = %{
+        attrs
+        | token: "synthetic-batch-last-access",
+          refresh_token: "synthetic-batch-last-refresh"
+      }
+
+      assert {:ok, second} = Upstreams.prepare_bundle_account(scope, pool, replacement)
+
+      assert {:ok, {:ok, [a, b]}} =
+               Repo.transaction(fn ->
+                 TokenLinking.link_prepared_batch_in_transaction(scope, pool, [first, second])
+               end)
+
+      assert a.identity.id == b.identity.id
+
+      assert {:ok, "synthetic-batch-last-refresh"} =
+               Secrets.decrypt_active_secret(b.identity, "refresh_token")
+    end
+  end
+
+  test "database rejection after the first batch entry rolls back the entire credential pair",
+       context do
+    %{scope: scope, pool: pool, attrs: attrs} = context
+    first = Map.put(attrs, :workspace_id, "workspace-first")
+    second = Map.put(attrs, :workspace_id, "workspace-second")
+    assert {:ok, a} = Upstreams.prepare_bundle_account(scope, pool, first)
+    assert {:ok, b} = Upstreams.prepare_bundle_account(scope, pool, second)
+    before = persistence_counts()
+    suffix = String.replace(Ecto.UUID.generate(), "-", "")
+    sequence = "import_fence_count_#{suffix}"
+    function = "import_fence_reject_#{suffix}"
+    trigger = "import_fence_trigger_#{suffix}"
+
+    # A PostgreSQL sequence survives rollback, proving both refresh inserts were
+    # reached (rather than only observing a failure during batch prevalidation).
+    Repo.query!("CREATE SEQUENCE #{sequence}")
+
+    Repo.query!("""
+    CREATE FUNCTION #{function}() RETURNS trigger LANGUAGE plpgsql AS $$
+    BEGIN
+      IF NEW.secret_kind = 'refresh_token' AND nextval('#{sequence}') = 2 THEN
+        RAISE EXCEPTION 'synthetic second refresh insert rejection';
+      END IF;
+      RETURN NEW;
+    END;
+    $$
+    """)
+
+    Repo.query!(
+      "CREATE TRIGGER #{trigger} BEFORE INSERT ON encrypted_secrets FOR EACH ROW EXECUTE FUNCTION #{function}()"
+    )
+
+    try do
+      assert_raise Postgrex.Error, ~r/synthetic second refresh insert rejection/, fn ->
+        Repo.transaction(fn ->
+          TokenLinking.link_prepared_batch_in_transaction(scope, pool, [a, b])
+        end)
+      end
+
+      assert %{rows: [[2]]} = Repo.query!("SELECT last_value FROM #{sequence}")
+      assert persistence_counts() == before
+    after
+      Repo.query!("DROP TRIGGER #{trigger} ON encrypted_secrets")
+      Repo.query!("DROP FUNCTION #{function}()")
+      Repo.query!("DROP SEQUENCE #{sequence}")
+    end
+  end
+
+  test "public bundle import rejects a refresh committed while waiting for batch locks",
+       context do
+    %{scope: scope, pool: pool, attrs: attrs} = context
+    password = "synthetic-import-bundle-password"
+    assert {:ok, %{identity: identity}} = Upstreams.import_trusted_account(scope, pool, attrs)
+    assert {:ok, bundle, _receipt} = UpstreamAccountBundle.export_bundle(pool, password)
+    parent = self()
+
+    holder =
+      Task.async(fn ->
+        Sandbox.unboxed_run(Repo, fn ->
+          Repo.transaction(fn ->
+            IdentitySlotLock.lock_slots!([attrs])
+            send(parent, :bundle_locked)
+
+            receive do
+              :release -> :ok
+            after
+              15_000 -> raise "bundle lock barrier timed out"
+            end
+          end)
+        end)
+      end)
+
+    assert_receive :bundle_locked, 5_000
+
+    importer =
+      Task.async(fn ->
+        Sandbox.unboxed_run(Repo, fn ->
+          %{rows: [[pid]]} = Repo.query!("SELECT pg_backend_pid()")
+          send(parent, {:bundle_started, pid})
+          UpstreamAccountBundle.import_bundle(bundle, pool, scope, password)
+        end)
+      end)
+
+    try do
+      assert_receive {:bundle_started, pid}, 5_000
+      wait_advisory!(pid, 500)
+      assert {:ok, %{status: :active}} = TokenRefresh.refresh_access_token(identity)
+      before = persistence_counts()
+      send(holder.pid, :release)
+      assert {:ok, :ok} = Task.await(holder, 5_000)
+      assert {:error, %{code: :bundle_import_failed}} = Task.await(importer, 5_000)
+      assert persistence_counts() == before
+      assert_rotated_pair(identity)
+    after
+      Task.shutdown(holder, :brutal_kill)
+      Task.shutdown(importer, :brutal_kill)
+    end
+  end
+
+  defp persistence_counts do
+    for schema <- [
+          UpstreamIdentity,
+          EncryptedSecret,
+          PoolUpstreamAssignment,
+          AuditEvent,
+          Oban.Job
+        ],
+        into: %{},
+        do: {schema, Repo.aggregate(schema, :count)}
+  end
+
+  defp assert_rotated_pair(identity) do
+    assert {:ok, "synthetic-rotated-access"} =
+             Secrets.decrypt_active_secret(identity, "access_token")
+
+    assert {:ok, "synthetic-rotated-refresh"} =
+             Secrets.decrypt_active_secret(identity, "refresh_token")
+  end
+
+  defp exported(attrs) do
+    Jason.encode!(%{
+      "tokens" => %{
+        "account_id" => attrs.chatgpt_account_id,
+        "id_token" => jwt(%{"email" => attrs.account_email}),
+        "access_token" => attrs.token,
+        "refresh_token" => attrs.refresh_token
+      }
+    })
+  end
+
+  defp jwt(claims),
+    do: "e30." <> Base.url_encode64(Jason.encode!(claims), padding: false) <> ".synthetic"
+
+  defp wait_advisory!(_pid, 0), do: flunk("public import never reached its slot lock")
+
+  defp wait_advisory!(pid, remaining) do
+    query =
+      "SELECT EXISTS (SELECT 1 FROM pg_locks WHERE pid=$1 AND locktype='advisory' AND NOT granted)"
+
+    case Repo.query!(query, [pid]).rows do
+      [[true]] ->
+        :ok
+
+      [[false]] ->
+        Process.sleep(10)
+        wait_advisory!(pid, remaining - 1)
+    end
+  end
+end


### PR DESCRIPTION
An auth.json import can prepare its account while another process refreshes the same credentials. After waiting for the existing persistence lock, the import currently writes its older token pair over that completed refresh. This change rejects that in-flight import with `stale_import` before any credential writes. A new explicit submission of the same export after the refresh remains accepted.

Import preparation captures the canonical identity ID, normalized slot, validated credential epoch and pending state (or explicit absence). Persistence compares that snapshot under the existing locks. Encrypted bundle imports validate all snapshots under the union of locks before writing, retaining duplicate-entry order and atomic rollback. Browser/device OAuth, invitation and relink preparation keep their current behavior. No schema change, automatic retry or additional refresh writer is introduced.

Validation:

- Public auth.json advisory-lock/refresh regression fails on pristine upstream; the separate explicit replacement case passes there and with this patch.
- 15 new regressions cover the public bundle race, absent/replaced identities, pending activation, legacy/invalid epochs, input isolation, duplicate entries and a database-triggered second-entry rollback.
- 521 lifecycle/import/OAuth regressions pass. The final full ordinary suite passes all four partitions; the required Unix profile passes all 59 tests.
- Formatting (including dev_support), warnings-as-errors compilation, architecture checks, strict Credo and independent source review pass.

Tests use synthetic credentials and PostgreSQL. This fences changes committed to canonical credential state after preparation; provider rotation before its database commit and crash recovery are separate concerns.
